### PR TITLE
fix: English-only currency symbols and chat section highlights

### DIFF
--- a/pages/api/roi-agent.js
+++ b/pages/api/roi-agent.js
@@ -140,11 +140,12 @@ export default async function handler(req, res) {
       callbacks: {
         onTextDelta: (delta) => send(res, { type: 'text_delta', delta }),
         onToolStart: (tool) => send(res, { type: 'tool_start', tool }),
-        onReportUpdate: (s) => {
+        onReportUpdate: (s, changedSections) => {
           const { renderedHtml, renderedFullHtml, ...rest } = s
           send(res, {
             type: 'report_update',
             state: { ...rest, renderedHtml, renderedFullHtml },
+            changedSections,
           })
         },
         onDone: (messages) =>

--- a/public/roi-exec-template.html
+++ b/public/roi-exec-template.html
@@ -211,6 +211,14 @@
         color: #fff !important;
         font-weight: bold;
       }
+
+      /* ── Chat section highlight ── */
+      [data-section].section-highlighted {
+        outline: 2px solid #2957ff;
+        outline-offset: 3px;
+        border-radius: 2px;
+        background-color: rgba(41, 87, 255, 0.06);
+      }
     </style>
   </head>
   <body>
@@ -251,7 +259,7 @@
         </div>
       </div>
 
-      <table class="kpi-bar">
+      <table class="kpi-bar" data-section="financials">
         <tr>
           <td class="kpi-cell">
             <div class="kpi-val">{{$json.display.statHours}}</div>
@@ -297,56 +305,66 @@
 
       <p>{{$json.display.blufParagraph}}</p>
 
-      <h2>The Pattern Underneath</h2>
-      <p>{{$json.display.unifiedPatternThesis}}</p>
-
-      <h2>Before vs. After AI</h2>
-      <table class="data-table">
-        <thead>
-          <tr>
-            <th>Workflow</th>
-            <th>Hrs/mo Now</th>
-            <th>Hrs/mo After AI</th>
-            <th>Hrs Saved/mo</th>
-            <th>Value/mo</th>
-            <th>AI Agent Deployed</th>
-          </tr>
-        </thead>
-        <tbody>
-          {{$json.display.bvaTableBodyCompact}}
-        </tbody>
-      </table>
-
-      <h2>Where the Profit Uplift Comes From</h2>
-      <div class="insight-panel">
-        <div class="stripe"></div>
-        <div class="panel-content">
-          <span class="panel-label">What is Profit Uplift?</span>
-          Operational Dividend = the value of hours freed from manual work.
-          Profit Uplift = what those freed hours produce when redirected to
-          higher-value activity. These are sequential effects of the same
-          improvement — not the same hours counted twice. Total Profit Uplift:
-          <strong>{{$json.display.statPU}} / yr</strong>
-        </div>
+      <div data-section="thesis">
+        <h2>The Pattern Underneath</h2>
+        <p>{{$json.display.unifiedPatternThesis}}</p>
       </div>
-      <table class="data-table">
-        <thead>
-          <tr>
-            <th style="width: 22%">Workflow</th>
-            <th style="width: 22%">Uplift Lever</th>
-            <th style="width: 56%">How It Works — Full Logic</th>
-          </tr>
-        </thead>
-        <tbody>
-          {{$json.display.profitUpliftLogicBody}}
-        </tbody>
-      </table>
 
-      <h2>Cost of Delay</h2>
-      {{$json.display.costOfDelayHTML}}
+      <div data-section="workflows">
+        <h2>Before vs. After AI</h2>
+        <table class="data-table">
+          <thead>
+            <tr>
+              <th>Workflow</th>
+              <th>Hrs/mo Now</th>
+              <th>Hrs/mo After AI</th>
+              <th>Hrs Saved/mo</th>
+              <th>Value/mo</th>
+              <th>AI Agent Deployed</th>
+            </tr>
+          </thead>
+          <tbody>
+            {{$json.display.bvaTableBodyCompact}}
+          </tbody>
+        </table>
+      </div>
 
-      <h2>What Happens Next</h2>
-      {{$json.display.nextStepsHTML}}
+      <div data-section="profit_levers">
+        <h2>Where the Profit Uplift Comes From</h2>
+        <div class="insight-panel">
+          <div class="stripe"></div>
+          <div class="panel-content">
+            <span class="panel-label">What is Profit Uplift?</span>
+            Operational Dividend = the value of hours freed from manual work.
+            Profit Uplift = what those freed hours produce when redirected to
+            higher-value activity. These are sequential effects of the same
+            improvement — not the same hours counted twice. Total Profit Uplift:
+            <strong>{{$json.display.statPU}} / yr</strong>
+          </div>
+        </div>
+        <table class="data-table">
+          <thead>
+            <tr>
+              <th style="width: 22%">Workflow</th>
+              <th style="width: 22%">Uplift Lever</th>
+              <th style="width: 56%">How It Works — Full Logic</th>
+            </tr>
+          </thead>
+          <tbody>
+            {{$json.display.profitUpliftLogicBody}}
+          </tbody>
+        </table>
+      </div>
+
+      <div data-section="cost_of_delay">
+        <h2>Cost of Delay</h2>
+        {{$json.display.costOfDelayHTML}}
+      </div>
+
+      <div data-section="cta">
+        <h2>What Happens Next</h2>
+        {{$json.display.nextStepsHTML}}
+      </div>
 
       <div class="page-footer">
         <span

--- a/public/roi-template.html
+++ b/public/roi-template.html
@@ -387,6 +387,14 @@
         color: #2957ff;
         font-weight: bold;
       }
+
+      /* ── Chat section highlight ── */
+      [data-section].section-highlighted {
+        outline: 2px solid #2957ff;
+        outline-offset: 3px;
+        border-radius: 2px;
+        background-color: rgba(41, 87, 255, 0.06);
+      }
     </style>
   </head>
   <body>
@@ -515,7 +523,7 @@
       <h2 style="margin-top: 10px">Executive Summary</h2>
 
       <!-- Unified Pattern Thesis (KR-16) -->
-      <div class="insight-panel">
+      <div class="insight-panel" data-section="thesis">
         <div class="insight-stripe"></div>
         <div class="insight-content">
           <p
@@ -682,7 +690,7 @@
       <div class="top-bar"></div>
 
       <!-- Before/After AI -->
-      <h2>Before vs. After AI Automation</h2>
+      <h2 data-section="workflows">Before vs. After AI Automation</h2>
       <table>
         <thead>
           <tr>
@@ -705,7 +713,7 @@
       {{$json.display.calculationPanelHTML}}
 
       <!-- Profit Uplift -->
-      <h2 style="margin-top: 10px">Profit Uplift Analysis</h2>
+      <h2 style="margin-top: 10px" data-section="profit_levers">Profit Uplift Analysis</h2>
       <p class="muted" style="margin-bottom: 4px">
         Downstream revenue and margin gains from redirecting recaptured
         capacity. All arithmetic is shown for transparency.
@@ -744,7 +752,7 @@
       <div class="top-bar"></div>
 
       <!-- Total Financial Case -->
-      <h2>Total Financial Case — 3-Year Projection</h2>
+      <h2 data-section="financials">Total Financial Case — 3-Year Projection</h2>
       <table>
         <thead>
           <tr>
@@ -789,11 +797,11 @@
       </p>
 
       <!-- Cost of Delay (KR-18) -->
-      <h2 style="margin-top: 10px">Cost of Delay</h2>
+      <h2 style="margin-top: 10px" data-section="cost_of_delay">Cost of Delay</h2>
       {{$json.display.costOfDelayHTML}}
 
       <!-- Resilience Positioning (KR-17) -->
-      <h2 style="margin-top: 10px">Resilience Positioning</h2>
+      <h2 style="margin-top: 10px" data-section="resilience_rows">Resilience Positioning</h2>
       <p style="font-size: 9pt; color: #2d2d2d; margin-bottom: 6px">
         The gap between automated and manual operations compounds over time —
         the following dimensions illustrate what acting now protects against.
@@ -816,7 +824,7 @@
       <div class="top-bar"></div>
 
       <!-- What We'd Deploy (WD-1) -->
-      <h2>What We'd Deploy</h2>
+      <h2 data-section="pilot">What We'd Deploy</h2>
       <table>
         <thead>
           <tr>
@@ -877,7 +885,7 @@
       <div class="top-bar"></div>
 
       <!-- Risks & Mitigations -->
-      <h2>Risks &amp; Mitigations</h2>
+      <h2 data-section="risks">Risks &amp; Mitigations</h2>
       <table>
         <thead>
           <tr>
@@ -922,7 +930,7 @@
       <div class="top-bar"></div>
 
       <!-- Next Steps (NS-1 + NS-2) -->
-      <h2>Next Steps</h2>
+      <h2 data-section="cta">Next Steps</h2>
       {{$json.display.nextStepsHTML}}
 
       <!-- Contact -->

--- a/src/components/ROIGenerator/ReportViewer.jsx
+++ b/src/components/ROIGenerator/ReportViewer.jsx
@@ -112,21 +112,24 @@ export default function ReportViewer({ initialState, email }) {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [chatHistory, streamingText, activeTool])
 
-  // Apply pending highlights after reportState updates.
-  // Handles the case where the HTML didn't change (same srcDoc) so onLoad never fires.
-  useEffect(() => {
-    const sections = pendingHighlightsRef.current
-    if (!sections.length) return
-    const doc = iframeRef.current?.contentDocument
-    // If the document has no data-section elements yet it's still loading — onLoad will handle it
-    if (!doc?.body?.querySelector('[data-section]')) return
-    pendingHighlightsRef.current = []
+  const applySectionHighlights = useCallback((doc, sections) => {
+    if (!doc?.body?.querySelector('[data-section]')) return false
     sections.forEach((section) => {
       doc.querySelectorAll(`[data-section="${section}"]`).forEach((el) => {
         el.classList.add('section-highlighted')
       })
     })
-  }, [reportState])
+    return true
+  }, [])
+
+  // Fallback: if srcDoc didn't change, onLoad won't fire — apply highlights directly.
+  useEffect(() => {
+    const sections = pendingHighlightsRef.current
+    if (!sections.length) return
+    const doc = iframeRef.current?.contentDocument
+    if (!applySectionHighlights(doc, sections)) return
+    pendingHighlightsRef.current = []
+  }, [reportState, applySectionHighlights])
 
   const activeHtml =
     activeTab === 'exec'
@@ -211,15 +214,11 @@ export default function ReportViewer({ initialState, email }) {
   const handleIframeLoad = useCallback(() => {
     const sections = pendingHighlightsRef.current
     if (!sections.length) return
-    pendingHighlightsRef.current = []
     const doc = iframeRef.current?.contentDocument
-    if (!doc) return
-    sections.forEach((section) => {
-      doc.querySelectorAll(`[data-section="${section}"]`).forEach((el) => {
-        el.classList.add('section-highlighted')
-      })
-    })
-  }, [])
+    if (applySectionHighlights(doc, sections)) {
+      pendingHighlightsRef.current = []
+    }
+  }, [applySectionHighlights])
 
   const handleDownload = useCallback(() => {
     iframeRef.current?.contentWindow?.print()

--- a/src/components/ROIGenerator/ReportViewer.jsx
+++ b/src/components/ROIGenerator/ReportViewer.jsx
@@ -67,6 +67,18 @@ const TOOL_LABELS = {
   remove_workflow: 'Removing workflow…',
 }
 
+const SECTION_LABELS = {
+  financials: 'KPI Bar',
+  thesis: 'The Pattern Underneath',
+  workflows: 'Before vs. After AI',
+  profit_levers: 'Profit Uplift',
+  cost_of_delay: 'Cost of Delay',
+  cta: 'What Happens Next',
+  resilience_rows: 'Resilience Table',
+  risks: 'Risks & Mitigations',
+  pilot: 'Pilot Recommendation',
+}
+
 // Render **bold** markdown from agent responses
 function renderText(text) {
   return text
@@ -90,9 +102,11 @@ export default function ReportViewer({ initialState, email }) {
   const [input, setInput] = useState('')
   const [emailStatus, setEmailStatus] = useState('idle')
   const [activeTab, setActiveTab] = useState('exec')
+  const [lastChangedSections, setLastChangedSections] = useState([])
 
   const iframeRef = useRef(null)
   const messagesEndRef = useRef(null)
+  const pendingHighlightsRef = useRef([])
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
@@ -114,6 +128,11 @@ export default function ReportViewer({ initialState, email }) {
       setChatHistory(newHistory)
       if (!overrideMsg) setInput('')
       setIsAgentRunning(true)
+      setLastChangedSections([])
+      // Clear any section highlights from the previous agent response
+      iframeRef.current?.contentDocument
+        ?.querySelectorAll('.section-highlighted')
+        .forEach((el) => el.classList.remove('section-highlighted'))
       setStreamingText('')
       setActiveTool(null)
 
@@ -142,6 +161,10 @@ export default function ReportViewer({ initialState, email }) {
           } else if (event.type === 'tool_start') {
             setActiveTool(TOOL_LABELS[event.tool] ?? event.tool)
           } else if (event.type === 'report_update') {
+            pendingHighlightsRef.current = event.changedSections ?? []
+            setLastChangedSections((prev) =>
+              [...new Set([...prev, ...(event.changedSections ?? [])])]
+            )
             setReportState(event.state)
             setActiveTool(null)
           } else if (event.type === 'done') {
@@ -168,6 +191,19 @@ export default function ReportViewer({ initialState, email }) {
     },
     [input, isAgentRunning, chatHistory, reportState],
   )
+
+  const handleIframeLoad = useCallback(() => {
+    const sections = pendingHighlightsRef.current
+    if (!sections.length) return
+    pendingHighlightsRef.current = []
+    const doc = iframeRef.current?.contentDocument
+    if (!doc) return
+    sections.forEach((section) => {
+      doc.querySelectorAll(`[data-section="${section}"]`).forEach((el) => {
+        el.classList.add('section-highlighted')
+      })
+    })
+  }, [])
 
   const handleDownload = useCallback(() => {
     iframeRef.current?.contentWindow?.print()
@@ -380,6 +416,7 @@ export default function ReportViewer({ initialState, email }) {
           <iframe
             ref={iframeRef}
             srcDoc={activeHtml ?? ''}
+            onLoad={handleIframeLoad}
             style={{ width: '100%', height: '100%', border: 'none' }}
             title="ROI Report Preview"
           />
@@ -443,6 +480,41 @@ export default function ReportViewer({ initialState, email }) {
                 </div>
               )
             })}
+
+            {/* Changed sections chips — shown after agent finishes */}
+            {!isAgentRunning && lastChangedSections.length > 0 && (
+              <div
+                style={{
+                  display: 'flex',
+                  flexWrap: 'wrap',
+                  alignItems: 'center',
+                  gap: 5,
+                  paddingLeft: 2,
+                }}
+              >
+                <span
+                  style={{ fontSize: 11, color: '#8a8aaa', flexShrink: 0 }}
+                >
+                  Sections updated:
+                </span>
+                {[...new Set(lastChangedSections)].map((s) => (
+                  <span
+                    key={s}
+                    style={{
+                      fontSize: 11,
+                      fontWeight: 500,
+                      background: '#eef2ff',
+                      color: '#2957ff',
+                      border: '1px solid #c7d2fe',
+                      borderRadius: 4,
+                      padding: '2px 7px',
+                    }}
+                  >
+                    {SECTION_LABELS[s] ?? s}
+                  </span>
+                ))}
+              </div>
+            )}
 
             {/* Agent working — tool label + streaming text in one assistant bubble */}
             {(activeTool || streamingText) && (

--- a/src/components/ROIGenerator/ReportViewer.jsx
+++ b/src/components/ROIGenerator/ReportViewer.jsx
@@ -112,6 +112,22 @@ export default function ReportViewer({ initialState, email }) {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
   }, [chatHistory, streamingText, activeTool])
 
+  // Apply pending highlights after reportState updates.
+  // Handles the case where the HTML didn't change (same srcDoc) so onLoad never fires.
+  useEffect(() => {
+    const sections = pendingHighlightsRef.current
+    if (!sections.length) return
+    const doc = iframeRef.current?.contentDocument
+    // If the document has no data-section elements yet it's still loading — onLoad will handle it
+    if (!doc?.body?.querySelector('[data-section]')) return
+    pendingHighlightsRef.current = []
+    sections.forEach((section) => {
+      doc.querySelectorAll(`[data-section="${section}"]`).forEach((el) => {
+        el.classList.add('section-highlighted')
+      })
+    })
+  }, [reportState])
+
   const activeHtml =
     activeTab === 'exec'
       ? reportState?.renderedHtml ?? initialState?.renderedHtml

--- a/src/lib/roi/agent.ts
+++ b/src/lib/roi/agent.ts
@@ -286,6 +286,10 @@ function buildTools(
 
           const modelerOut = result.object as ModelerResult
 
+          const rawCurrencySym = modelerOut.currency.symbol
+          const cleanSym = /[^\x00-\x7F]/.test(rawCurrencySym)
+            ? modelerOut.currency.code
+            : rawCurrencySym
           globals = {
             laborRate: modelerOut.labor.fullyLoadedHourlyCost,
             implementationCost: modelerOut.costs.implementationCost,
@@ -293,7 +297,12 @@ function buildTools(
             profitMultiplier: modelerOut.profitMultiplier,
             realizationFactor: modelerOut.realizationFactor,
             workWeeksPerYear: modelerOut.labor.workWeeksPerYear,
-            currency: modelerOut.currency,
+            currency: {
+              ...modelerOut.currency,
+              symbol: cleanSym.length > 1 && !cleanSym.endsWith(' ')
+                ? cleanSym + ' '
+                : cleanSym,
+            },
           }
 
           // Merge per-workflow assumptions from modeler into state.workflows
@@ -1038,7 +1047,10 @@ function buildChatSystemPrompt(state: ReportState): string {
   const copy = state.copy!
   const company = state.company!
   const globals = state.globals!
-  const sym = globals.currency.symbol
+  // Fall back to ISO code if symbol contains non-ASCII characters (e.g. Arabic script)
+  const sym = /[^\x00-\x7F]/.test(globals.currency.symbol)
+    ? globals.currency.code + ' '
+    : globals.currency.symbol
   const s = calc.summary
 
   // Merge WorkflowInput (raw) with WorkflowCalc (derived) by name

--- a/src/lib/roi/agent.ts
+++ b/src/lib/roi/agent.ts
@@ -1052,6 +1052,7 @@ function buildChatSystemPrompt(state: ReportState): string {
   const company = state.company!
   const globals = state.globals!
   // Fall back to ISO code if symbol contains non-ASCII characters (e.g. Arabic script)
+  // eslint-disable-next-line no-control-regex
   const sym = /[^\x00-\x7F]/.test(globals.currency.symbol)
     ? globals.currency.code + ' '
     : globals.currency.symbol

--- a/src/lib/roi/agent.ts
+++ b/src/lib/roi/agent.ts
@@ -71,6 +71,7 @@ function reAssemble(
   execTemplateHtml: string,
   fullTemplateHtml: string,
   callbacks: AgentCallbacks,
+  changedSections?: string[],
 ) {
   if (!state.workflows || !state.globals || !state.company) return
   state.calcOutput = roiCalculator(
@@ -82,7 +83,7 @@ function reAssemble(
   state.assembled = assembleReport(state)
   state.renderedHtml = renderTemplate(execTemplateHtml, state.assembled)
   state.renderedFullHtml = renderTemplate(fullTemplateHtml, state.assembled)
-  callbacks.onReportUpdate(state)
+  callbacks.onReportUpdate(state, changedSections)
 }
 
 // ── Tool definitions ──────────────────────────────────────────────────────────
@@ -473,7 +474,9 @@ function buildTools(
       }),
       execute: async (copy: ReportCopy) => {
         state.copy = copy
-        reAssemble(state, execTemplateHtml, fullTemplateHtml, callbacks)
+        reAssemble(state, execTemplateHtml, fullTemplateHtml, callbacks, [
+          'thesis', 'workflows', 'profit_levers', 'cost_of_delay', 'cta',
+        ])
         return { ok: true }
       },
     }),
@@ -596,11 +599,22 @@ function buildTools(
             next_steps_checklist: patches.next_steps,
           }),
         }
-        reAssemble(state, execTemplateHtml, fullTemplateHtml, callbacks)
-        const updated = Object.keys(patches).filter(
-          (k) => patches[k as keyof typeof patches] !== undefined,
-        )
-        return { ok: true, updated_sections: updated }
+        const COPY_TO_SECTION: Record<string, string> = {
+          thesis: 'thesis',
+          cta: 'cta',
+          pilot: 'pilot',
+          profit_levers: 'profit_levers',
+          resilience_rows: 'resilience_rows',
+          cost_of_delay: 'cost_of_delay',
+          risks: 'risks',
+          next_steps: 'cta',
+        }
+        const changedSections = Object.keys(patches)
+          .filter((k) => patches[k as keyof typeof patches] !== undefined)
+          .map((k) => COPY_TO_SECTION[k])
+          .filter(Boolean)
+        reAssemble(state, execTemplateHtml, fullTemplateHtml, callbacks, changedSections)
+        return { ok: true, updated_sections: changedSections }
       },
     }),
 
@@ -672,7 +686,7 @@ function buildTools(
                 }),
               },
         )
-        reAssemble(state, execTemplateHtml, fullTemplateHtml, callbacks)
+        reAssemble(state, execTemplateHtml, fullTemplateHtml, callbacks, ['workflows', 'financials'])
         const s = state.calcOutput?.summary
         return {
           ok: true,
@@ -754,7 +768,7 @@ function buildTools(
             'Added via chat — defaults applied. Use update_workflow to refine.',
         }
         state.workflows = [...state.workflows, newWorkflow]
-        reAssemble(state, execTemplateHtml, fullTemplateHtml, callbacks)
+        reAssemble(state, execTemplateHtml, fullTemplateHtml, callbacks, ['workflows', 'financials'])
         return { ok: true, workflow_count: state.workflows.length }
       },
     }),
@@ -766,7 +780,7 @@ function buildTools(
       execute: async ({ workflowName }: { workflowName: string }) => {
         if (!state.workflows) return { error: 'No workflows' }
         state.workflows = state.workflows.filter((w) => w.name !== workflowName)
-        reAssemble(state, execTemplateHtml, fullTemplateHtml, callbacks)
+        reAssemble(state, execTemplateHtml, fullTemplateHtml, callbacks, ['workflows', 'financials'])
         return { ok: true, workflow_count: state.workflows.length }
       },
     }),
@@ -812,7 +826,7 @@ function buildTools(
             revenueEstimateM: state.company.revenueEstimateM * multiplier,
           }
         }
-        reAssemble(state, execTemplateHtml, fullTemplateHtml, callbacks)
+        reAssemble(state, execTemplateHtml, fullTemplateHtml, callbacks, ['financials'])
         return { ok: true, multiplier }
       },
     }),
@@ -859,7 +873,7 @@ function buildTools(
         if (state.globals) state.globals = { ...state.globals, currency }
         if (state.normInput)
           state.normInput = { ...state.normInput, selectedCurrency: code }
-        reAssemble(state, execTemplateHtml, fullTemplateHtml, callbacks)
+        reAssemble(state, execTemplateHtml, fullTemplateHtml, callbacks, ['financials'])
         return { ok: true, currency }
       },
     }),
@@ -915,7 +929,7 @@ function buildTools(
             realizationFactor: patches.realizationFactor,
           }),
         }
-        reAssemble(state, execTemplateHtml, fullTemplateHtml, callbacks)
+        reAssemble(state, execTemplateHtml, fullTemplateHtml, callbacks, ['financials'])
         const s = state.calcOutput?.summary
         return {
           ok: true,

--- a/src/lib/roi/agent.ts
+++ b/src/lib/roi/agent.ts
@@ -286,8 +286,12 @@ function buildTools(
 
           const modelerOut = result.object as ModelerResult
 
+          // Currencies whose official symbols are non-Latin script — always use the ISO code instead
+          const SCRIPT_SYMBOL_CODES = new Set(['SAR', 'AED', 'QAR', 'KWD', 'BHD', 'OMR', 'EGP', 'JOD', 'IQD', 'LBP', 'IRR', 'YER'])
           const rawCurrencySym = modelerOut.currency.symbol
-          const cleanSym = /[^\x00-\x7F]/.test(rawCurrencySym)
+          // eslint-disable-next-line no-control-regex
+          const hasNonAscii = /[^\x00-\x7F]/.test(rawCurrencySym)
+          const cleanSym = SCRIPT_SYMBOL_CODES.has(modelerOut.currency.code) || hasNonAscii
             ? modelerOut.currency.code
             : rawCurrencySym
           globals = {

--- a/src/lib/roi/pipeline/assembleReport.ts
+++ b/src/lib/roi/pipeline/assembleReport.ts
@@ -429,7 +429,10 @@ export function assembleReport(state: ReportState): AssembleReportOutput {
     throw new Error('assembleReport: missing required state fields')
   }
 
-  const sym = globals.currency.symbol
+  const rawSym = /[^\x00-\x7F]/.test(globals.currency.symbol)
+    ? globals.currency.code
+    : globals.currency.symbol
+  const sym = rawSym.length > 1 && !rawSym.endsWith(' ') ? rawSym + ' ' : rawSym
   const s = calcOutput.summary
 
   const fmt = (n: number | null | undefined) =>

--- a/src/lib/roi/pipeline/assembleReport.ts
+++ b/src/lib/roi/pipeline/assembleReport.ts
@@ -429,7 +429,11 @@ export function assembleReport(state: ReportState): AssembleReportOutput {
     throw new Error('assembleReport: missing required state fields')
   }
 
-  const rawSym = /[^\x00-\x7F]/.test(globals.currency.symbol)
+  // Currencies whose official symbols are non-Latin script — always use the ISO code instead
+  const SCRIPT_SYMBOL_CODES = new Set(['SAR', 'AED', 'QAR', 'KWD', 'BHD', 'OMR', 'EGP', 'JOD', 'IQD', 'LBP', 'IRR', 'YER'])
+  // eslint-disable-next-line no-control-regex
+  const hasNonAscii = /[^\x00-\x7F]/.test(globals.currency.symbol)
+  const rawSym = SCRIPT_SYMBOL_CODES.has(globals.currency.code) || hasNonAscii
     ? globals.currency.code
     : globals.currency.symbol
   const sym = rawSym.length > 1 && !rawSym.endsWith(' ') ? rawSym + ' ' : rawSym

--- a/src/lib/roi/pipeline/roiCalculator.ts
+++ b/src/lib/roi/pipeline/roiCalculator.ts
@@ -54,7 +54,10 @@ export function roiCalculator(
   globals: GlobalInputs,
   company: CompanyProfile,
 ): RoiCalculatorOutput {
-  const sym = globals.currency.symbol
+  const rawSym = /[^\x00-\x7F]/.test(globals.currency.symbol)
+    ? globals.currency.code
+    : globals.currency.symbol
+  const sym = rawSym.length > 1 && !rawSym.endsWith(' ') ? rawSym + ' ' : rawSym
   const workingMonthFactor = globals.workWeeksPerYear / 52
 
   const workflowCalcs: WorkflowCalc[] = workflows.map((wf) => {

--- a/src/lib/roi/pipeline/roiCalculator.ts
+++ b/src/lib/roi/pipeline/roiCalculator.ts
@@ -54,7 +54,11 @@ export function roiCalculator(
   globals: GlobalInputs,
   company: CompanyProfile,
 ): RoiCalculatorOutput {
-  const rawSym = /[^\x00-\x7F]/.test(globals.currency.symbol)
+  // Currencies whose official symbols are non-Latin script — always use the ISO code instead
+  const SCRIPT_SYMBOL_CODES = new Set(['SAR', 'AED', 'QAR', 'KWD', 'BHD', 'OMR', 'EGP', 'JOD', 'IQD', 'LBP', 'IRR', 'YER'])
+  // eslint-disable-next-line no-control-regex
+  const hasNonAscii = /[^\x00-\x7F]/.test(globals.currency.symbol)
+  const rawSym = SCRIPT_SYMBOL_CODES.has(globals.currency.code) || hasNonAscii
     ? globals.currency.code
     : globals.currency.symbol
   const sym = rawSym.length > 1 && !rawSym.endsWith(' ') ? rawSym + ' ' : rawSym

--- a/src/lib/roi/prompts/roiModeler.ts
+++ b/src/lib/roi/prompts/roiModeler.ts
@@ -12,7 +12,7 @@ each with research-derived monthlyVolume and minutesPerItemBefore),
 processes[] (questionnaire data), selectedCurrency.
 
 CURRENCY: Parse from selectedCurrency (format "CODE – Name (symbol)").
-Use exact GCC symbols: SAR→"ر.س", AED→"د.إ", QAR→"ر.ق", KWD→"د.ك", BHD→"BD", OMR→"ر.ع.".
+Always use English/Latin symbols only — never Arabic script. GCC currencies: SAR→"SAR", AED→"AED", QAR→"QAR", KWD→"KWD", BHD→"BHD", OMR→"OMR".
 If blank, infer from country.
 
 VOLUME & TIME ANCHORING:

--- a/src/lib/roi/types.ts
+++ b/src/lib/roi/types.ts
@@ -320,7 +320,7 @@ export interface ReportState {
 export interface AgentCallbacks {
   onTextDelta(delta: string): void
   onToolStart(toolName: string): void
-  onReportUpdate(state: ReportState): void
+  onReportUpdate(state: ReportState, changedSections?: string[]): void
   onDone(newMessages: import('ai').ModelMessage[]): void
   onError(err: Error): void
 }


### PR DESCRIPTION
## What changed

### 1. Currency symbol fix
GCC currencies (SAR, AED, QAR, etc.) were rendering in Arabic script (ر.س) throughout the report. All figures now display Latin codes (e.g. SAR 286K).

Fixed at three layers:
- `agent.ts` — normalize at source when modeler returns Arabic symbol
- `assembleReport.ts` — normalize before formatting display strings
- `roiCalculator.ts` — normalize before formatting display strings

### 2. Chat section highlights
When the agent updates the report via chat, affected sections are highlighted with a blue outline and listed as chips in the chat panel. Highlights persist until the next message is sent.

## Test plan
- [ ] Generate a report with SAR currency — figures show SAR not ر.س
- [ ] Use chat to update something — affected sections highlight in blue, chips appear
- [ ] Highlights clear when next message is sent

<img width="1470" height="803" alt="Screenshot 2026-04-22 at 5 53 18 PM" src="https://github.com/user-attachments/assets/9330194a-dcda-450f-afd7-995f066c9e97" />
