### PR TITLE
feat: add user activity tracking and admin dashboard

### DIFF
--- a/pages/api/reports/[id].js
+++ b/pages/api/reports/[id].js
@@ -36,7 +36,9 @@ export default async function handler(req, res) {
     admin
       .from('events')
       .insert({ user_id: user.id, report_id: id, type: 'report_viewed' })
-      .then(() => {})
+      .then(({ error }) => {
+        if (error) console.error('event insert failed (report_viewed)', error)
+      })
 
     return res.status(200).json({
       renderedHtml: report.rendered_html,

--- a/pages/api/reports/[id].js
+++ b/pages/api/reports/[id].js
@@ -33,6 +33,11 @@ export default async function handler(req, res) {
     if (!isEmployee && report.user_id !== user.id)
       return res.status(403).json({ error: 'Forbidden' })
 
+    admin
+      .from('events')
+      .insert({ user_id: user.id, report_id: id, type: 'report_viewed' })
+      .then(() => {})
+
     return res.status(200).json({
       renderedHtml: report.rendered_html,
       renderedFullHtml: report.rendered_full_html,

--- a/pages/api/roi-agent.js
+++ b/pages/api/roi-agent.js
@@ -182,7 +182,10 @@ export default async function handler(req, res) {
             report_id: reportId,
             type: 'chat_limit_reached',
           })
-          .then(() => {})
+          .then(({ error }) => {
+            if (error)
+              console.error('event insert failed (chat_limit_reached)', error)
+          })
         res.status(403).json({ error: 'limit_reached' })
         return
       }
@@ -362,7 +365,10 @@ export default async function handler(req, res) {
           report_id: reportId,
           type: 'chat_message_sent',
         })
-        .then(() => {})
+        .then(({ error }) => {
+          if (error)
+            console.error('event insert failed (chat_message_sent)', error)
+        })
 
       if (userRole !== 'EMPLOYEE') {
         const { data: usage, error: usageReadErr } = await adminSupabase
@@ -444,7 +450,10 @@ export default async function handler(req, res) {
             report_id: savedReport.id,
             type: 'report_created',
           })
-          .then(() => {})
+          .then(({ error }) => {
+            if (error)
+              console.error('event insert failed (report_created)', error)
+          })
         send(res, { type: 'report_saved', report_id: savedReport.id })
       }
     }

--- a/pages/api/roi-agent.js
+++ b/pages/api/roi-agent.js
@@ -355,6 +355,15 @@ export default async function handler(req, res) {
 
       await persistReportEvidence(adminSupabase, reportId, state.evidenceItems)
 
+      adminSupabase
+        .from('events')
+        .insert({
+          user_id: user.id,
+          report_id: reportId,
+          type: 'chat_message_sent',
+        })
+        .then(() => {})
+
       if (userRole !== 'EMPLOYEE') {
         const { data: usage, error: usageReadErr } = await adminSupabase
           .from('chat_usage')
@@ -428,6 +437,14 @@ export default async function handler(req, res) {
           savedReport.id,
           state.evidenceItems,
         )
+        adminSupabase
+          .from('events')
+          .insert({
+            user_id: user.id,
+            report_id: savedReport.id,
+            type: 'report_created',
+          })
+          .then(() => {})
         send(res, { type: 'report_saved', report_id: savedReport.id })
       }
     }

--- a/pages/dashboard.jsx
+++ b/pages/dashboard.jsx
@@ -1,9 +1,12 @@
 import Head from 'next/head'
 import Link from 'next/link'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useRouter } from 'next/router'
 import { FaTrash } from 'react-icons/fa'
-import { createClient as createServerClient } from '../src/lib/supabase-server'
+import {
+  createClient as createServerClient,
+  createAdminClient,
+} from '../src/lib/supabase-server'
 import { createClient as createBrowserClient } from '../src/lib/supabase-browser'
 import MainHeader from '../src/layout/MainHeader'
 
@@ -12,6 +15,20 @@ const STATUS_STYLES = {
   RUNNING: { bg: 'bg-blue-50', text: 'text-blue-700', label: 'Running' },
   FAILED: { bg: 'bg-red-50', text: 'text-red-600', label: 'Failed' },
   PENDING: { bg: 'bg-gray-100', text: 'text-gray-500', label: 'Pending' },
+}
+
+const EVENT_LABELS = {
+  report_created: 'generated a report',
+  report_viewed: 'viewed a report',
+  chat_message_sent: 'sent a chat message',
+  chat_limit_reached: 'reached the chat limit',
+}
+
+const EVENT_COLORS = {
+  report_created: 'bg-green-400',
+  report_viewed: 'bg-blue-400',
+  chat_message_sent: 'bg-purple-400',
+  chat_limit_reached: 'bg-orange-400',
 }
 
 function StatusBadge({ status }) {
@@ -34,6 +51,29 @@ function formatDate(iso) {
   })
 }
 
+function timeAgo(iso) {
+  if (!iso) return '—'
+  const diff = Date.now() - new Date(iso).getTime()
+  const mins = Math.floor(diff / 60000)
+  if (mins < 1) return 'just now'
+  if (mins < 60) return `${mins}m ago`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `${hrs}h ago`
+  const days = Math.floor(hrs / 24)
+  return `${days}d ago`
+}
+
+function StatCard({ label, value }) {
+  return (
+    <div className="bg-white rounded-2xl border border-gray-100 shadow-sm px-6 py-5">
+      <p className="font-outfit text-[11px] uppercase tracking-wider text-gray-400 font-semibold mb-1">
+        {label}
+      </p>
+      <p className="font-outfit text-3xl font-bold text-[#2C2C2C]">{value}</p>
+    </div>
+  )
+}
+
 export async function getServerSideProps({ req, res }) {
   const supabase = createServerClient(req, res)
   const {
@@ -48,7 +88,9 @@ export async function getServerSideProps({ req, res }) {
 
   let query = supabase
     .from('reports')
-    .select('id, company_name, email, status, created_at, completed_at')
+    .select(
+      'id, user_id, company_name, email, status, created_at, completed_at',
+    )
     .order('created_at', { ascending: false })
 
   if (!isEmployee) {
@@ -57,11 +99,69 @@ export async function getServerSideProps({ req, res }) {
 
   const { data: reports } = await query
 
+  if (!isEmployee) {
+    return {
+      props: {
+        user: {
+          email: user.email,
+          name: user.user_metadata?.full_name ?? null,
+        },
+        isEmployee,
+        reports: reports ?? [],
+        users: [],
+        recentEvents: [],
+      },
+    }
+  }
+
+  const admin = createAdminClient()
+  const [{ data: allUsers }, { data: allReports }, { data: rawEvents }] =
+    await Promise.all([
+      admin
+        .from('users')
+        .select('id, email, role, created_at')
+        .order('created_at', { ascending: false }),
+      admin.from('reports').select('id, user_id, created_at'),
+      admin
+        .from('events')
+        .select('user_id, type, report_id, created_at')
+        .order('created_at', { ascending: false })
+        .limit(50),
+    ])
+
+  const reportCountByUser = (allReports ?? []).reduce((acc, r) => {
+    acc[r.user_id] = (acc[r.user_id] ?? 0) + 1
+    return acc
+  }, {})
+
+  const lastActiveByUser = (rawEvents ?? []).reduce((acc, e) => {
+    if (!acc[e.user_id]) acc[e.user_id] = e.created_at
+    return acc
+  }, {})
+
+  const usersWithStats = (allUsers ?? []).map((u) => ({
+    ...u,
+    report_count: reportCountByUser[u.id] ?? 0,
+    last_active: lastActiveByUser[u.id] ?? null,
+  }))
+
+  const userEmailById = (allUsers ?? []).reduce((acc, u) => {
+    acc[u.id] = u.email
+    return acc
+  }, {})
+  const recentEvents = (rawEvents ?? []).map((e) => ({
+    ...e,
+    user_email: userEmailById[e.user_id] ?? 'Unknown',
+  }))
+
   return {
     props: {
       user: { email: user.email, name: user.user_metadata?.full_name ?? null },
       isEmployee,
+      userId: user.id,
       reports: reports ?? [],
+      users: usersWithStats,
+      recentEvents,
     },
   }
 }
@@ -70,12 +170,23 @@ export default function Dashboard({
   user,
   reports: initialReports,
   isEmployee,
+  userId,
+  users,
+  recentEvents,
 }) {
   const router = useRouter()
   const [reports, setReports] = useState(initialReports)
   const [confirmingId, setConfirmingId] = useState(null)
   const [deletingId, setDeletingId] = useState(null)
   const [navigatingId, setNavigatingId] = useState(null)
+  const [activeTab, setActiveTab] = useState('Reports')
+
+  useEffect(() => {
+    if (isEmployee && router.query.tab === 'my-reports')
+      setActiveTab('My Reports')
+  }, [isEmployee, router.query.tab])
+
+  const myReports = reports.filter((r) => r.user_id === userId)
 
   const handleSignOut = async () => {
     const supabase = createBrowserClient()
@@ -96,20 +207,27 @@ export default function Dashboard({
     }
   }
 
+  const oneWeekAgo = new Date(
+    Date.now() - 7 * 24 * 60 * 60 * 1000,
+  ).toISOString()
+  const reportsThisWeek = reports.filter(
+    (r) => r.created_at >= oneWeekAgo,
+  ).length
+
   return (
     <div className="rebranding-landing-page min-h-screen -mt-[12px]">
       <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
       <MainHeader />
       <Head>
-        <title>{isEmployee ? 'All Reports' : 'My Reports'} | LyRise</title>
+        <title>{isEmployee ? 'Admin Dashboard' : 'My Reports'} | LyRise</title>
       </Head>
 
-      <div className="max-w-4xl mx-auto px-4 py-12">
+      <div className="max-w-5xl mx-auto px-4 py-12">
         {/* Header row */}
         <div className="flex items-center justify-between mb-8">
           <div>
             <h1 className="font-outfit text-2xl font-bold text-[#2C2C2C]">
-              {isEmployee ? 'All Reports' : 'My Reports'}
+              {isEmployee ? 'Admin Dashboard' : 'My Reports'}
             </h1>
             <p className="font-outfit text-sm text-gray-500 mt-0.5">
               {user.email}
@@ -132,132 +250,274 @@ export default function Dashboard({
           </div>
         </div>
 
-        {/* Table */}
-        {reports.length === 0 ? (
-          <div className="text-center py-20 bg-white rounded-2xl border border-gray-100 shadow-sm">
-            <p className="font-outfit text-gray-400 text-sm mb-4">
-              No reports yet.
-            </p>
-            <Link
-              href="/roi-report"
-              className="font-outfit text-sm font-semibold text-white bg-[#2C2C2C] hover:bg-black transition-colors rounded-full px-6 py-3"
-            >
-              Generate your first report
-            </Link>
-          </div>
-        ) : (
+        {/* Employee: stats + tabs */}
+        {isEmployee && (
+          <>
+            <div className="grid grid-cols-3 gap-4 mb-6">
+              <StatCard label="Total Users" value={users.length} />
+              <StatCard label="Total Reports" value={reports.length} />
+              <StatCard label="Reports This Week" value={reportsThisWeek} />
+            </div>
+
+            <div className="flex gap-1 mb-6 bg-gray-100 p-1 rounded-xl w-fit">
+              {['Reports', 'My Reports', 'Users', 'Activity'].map((tab) => (
+                <button
+                  key={tab}
+                  type="button"
+                  onClick={() => setActiveTab(tab)}
+                  className={`font-outfit text-sm font-medium px-4 py-1.5 rounded-lg transition-colors ${
+                    activeTab === tab
+                      ? 'bg-white text-[#2C2C2C] shadow-sm'
+                      : 'text-gray-500 hover:text-gray-700'
+                  }`}
+                >
+                  {tab}
+                </button>
+              ))}
+            </div>
+          </>
+        )}
+
+        {/* Reports tab */}
+        {(!isEmployee ||
+          activeTab === 'Reports' ||
+          activeTab === 'My Reports') &&
+          ((activeTab === 'My Reports' ? myReports : reports).length === 0 ? (
+            <div className="text-center py-20 bg-white rounded-2xl border border-gray-100 shadow-sm">
+              <p className="font-outfit text-gray-400 text-sm mb-4">
+                No reports yet.
+              </p>
+              <Link
+                href="/roi-report"
+                className="font-outfit text-sm font-semibold text-white bg-[#2C2C2C] hover:bg-black transition-colors rounded-full px-6 py-3"
+              >
+                Generate your first report
+              </Link>
+            </div>
+          ) : (
+            <div className="bg-white rounded-2xl border border-gray-100 shadow-sm overflow-hidden">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-gray-100">
+                    <th className="font-outfit font-semibold text-[11px] uppercase tracking-wider text-gray-400 text-left px-6 py-3.5">
+                      Company
+                    </th>
+                    <th className="font-outfit font-semibold text-[11px] uppercase tracking-wider text-gray-400 text-left px-6 py-3.5">
+                      Email
+                    </th>
+                    <th className="font-outfit font-semibold text-[11px] uppercase tracking-wider text-gray-400 text-left px-6 py-3.5">
+                      Status
+                    </th>
+                    <th className="font-outfit font-semibold text-[11px] uppercase tracking-wider text-gray-400 text-left px-6 py-3.5">
+                      Date
+                    </th>
+                    <th className="px-6 py-3.5" />
+                  </tr>
+                </thead>
+                <tbody>
+                  {(activeTab === 'My Reports' ? myReports : reports).map(
+                    (r, i) => {
+                      const clickable = isEmployee || r.status === 'SUCCESS'
+                      return (
+                        <tr
+                          key={r.id}
+                          onClick={() => {
+                            if (!clickable || navigatingId) return
+                            setNavigatingId(r.id)
+                            router.push(`/report/${r.id}`)
+                          }}
+                          className={`${
+                            i <
+                            (activeTab === 'My Reports' ? myReports : reports)
+                              .length -
+                              1
+                              ? 'border-b border-gray-50'
+                              : ''
+                          } hover:bg-gray-50 transition-colors ${
+                            clickable && !navigatingId
+                              ? 'cursor-pointer'
+                              : 'cursor-default'
+                          }`}
+                        >
+                          <td className="font-outfit font-medium text-[#2C2C2C] px-6 py-4">
+                            {r.company_name || '—'}
+                          </td>
+                          <td className="font-outfit text-gray-500 px-6 py-4">
+                            {r.email || '—'}
+                          </td>
+                          <td className="px-6 py-4">
+                            <StatusBadge status={r.status} />
+                          </td>
+                          <td className="font-outfit text-gray-400 px-6 py-4">
+                            {formatDate(r.created_at)}
+                          </td>
+                          <td
+                            className="px-6 py-4 text-right"
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            <div className="flex items-center justify-end gap-3">
+                              {clickable &&
+                                (navigatingId === r.id ? (
+                                  <span
+                                    style={{
+                                      display: 'inline-block',
+                                      width: 14,
+                                      height: 14,
+                                      border: '2px solid #e2e8f0',
+                                      borderTopColor: '#2957FF',
+                                      borderRadius: '50%',
+                                      animation: 'spin 0.75s linear infinite',
+                                      flexShrink: 0,
+                                    }}
+                                  />
+                                ) : (
+                                  <span className="font-outfit text-xs font-semibold text-[#2957FF]">
+                                    View →
+                                  </span>
+                                ))}
+                              {isEmployee &&
+                                (confirmingId === r.id ? (
+                                  <span className="flex items-center gap-2">
+                                    <button
+                                      type="button"
+                                      onClick={() => handleDelete(r.id)}
+                                      disabled={deletingId === r.id}
+                                      className="font-outfit text-xs font-semibold text-red-600 hover:text-red-800 transition-colors disabled:opacity-50"
+                                    >
+                                      {deletingId === r.id
+                                        ? 'Deleting…'
+                                        : 'Confirm'}
+                                    </button>
+                                    <button
+                                      type="button"
+                                      onClick={() => setConfirmingId(null)}
+                                      className="font-outfit text-xs text-gray-400 hover:text-gray-600 transition-colors"
+                                    >
+                                      Cancel
+                                    </button>
+                                  </span>
+                                ) : (
+                                  <button
+                                    type="button"
+                                    onClick={() => setConfirmingId(r.id)}
+                                    className="text-gray-300 hover:text-red-500 transition-colors"
+                                    title="Delete report"
+                                  >
+                                    <FaTrash size={13} />
+                                  </button>
+                                ))}
+                            </div>
+                          </td>
+                        </tr>
+                      )
+                    },
+                  )}
+                </tbody>
+              </table>
+            </div>
+          ))}
+
+        {/* Users tab */}
+        {isEmployee && activeTab === 'Users' && (
           <div className="bg-white rounded-2xl border border-gray-100 shadow-sm overflow-hidden">
             <table className="w-full text-sm">
               <thead>
                 <tr className="border-b border-gray-100">
                   <th className="font-outfit font-semibold text-[11px] uppercase tracking-wider text-gray-400 text-left px-6 py-3.5">
-                    Company
-                  </th>
-                  <th className="font-outfit font-semibold text-[11px] uppercase tracking-wider text-gray-400 text-left px-6 py-3.5">
                     Email
                   </th>
                   <th className="font-outfit font-semibold text-[11px] uppercase tracking-wider text-gray-400 text-left px-6 py-3.5">
-                    Status
+                    Role
                   </th>
                   <th className="font-outfit font-semibold text-[11px] uppercase tracking-wider text-gray-400 text-left px-6 py-3.5">
-                    Date
+                    Reports
                   </th>
-                  <th className="px-6 py-3.5" />
+                  <th className="font-outfit font-semibold text-[11px] uppercase tracking-wider text-gray-400 text-left px-6 py-3.5">
+                    Joined
+                  </th>
+                  <th className="font-outfit font-semibold text-[11px] uppercase tracking-wider text-gray-400 text-left px-6 py-3.5">
+                    Last Active
+                  </th>
                 </tr>
               </thead>
               <tbody>
-                {reports.map((r, i) => {
-                  const clickable = isEmployee || r.status === 'SUCCESS'
-                  return (
+                {users.length === 0 ? (
+                  <tr>
+                    <td
+                      colSpan={5}
+                      className="font-outfit text-gray-400 text-sm text-center px-6 py-12"
+                    >
+                      No users found.
+                    </td>
+                  </tr>
+                ) : (
+                  users.map((u, i) => (
                     <tr
-                      key={r.id}
-                      onClick={() => {
-                        if (!clickable || navigatingId) return
-                        setNavigatingId(r.id)
-                        router.push(`/report/${r.id}`)
-                      }}
-                      className={`${
-                        i < reports.length - 1 ? 'border-b border-gray-50' : ''
-                      } hover:bg-gray-50 transition-colors ${
-                        clickable && !navigatingId
-                          ? 'cursor-pointer'
-                          : 'cursor-default'
-                      }`}
+                      key={u.id}
+                      className={
+                        i < users.length - 1 ? 'border-b border-gray-50' : ''
+                      }
                     >
                       <td className="font-outfit font-medium text-[#2C2C2C] px-6 py-4">
-                        {r.company_name || '—'}
-                      </td>
-                      <td className="font-outfit text-gray-500 px-6 py-4">
-                        {r.email || '—'}
+                        {u.email}
                       </td>
                       <td className="px-6 py-4">
-                        <StatusBadge status={r.status} />
+                        <span
+                          className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold ${
+                            u.role === 'EMPLOYEE'
+                              ? 'bg-blue-50 text-blue-700'
+                              : 'bg-gray-100 text-gray-500'
+                          }`}
+                        >
+                          {u.role ?? 'CLIENT'}
+                        </span>
+                      </td>
+                      <td className="font-outfit text-gray-500 px-6 py-4">
+                        {u.report_count}
                       </td>
                       <td className="font-outfit text-gray-400 px-6 py-4">
-                        {formatDate(r.created_at)}
+                        {formatDate(u.created_at)}
                       </td>
-                      <td
-                        className="px-6 py-4 text-right"
-                        onClick={(e) => e.stopPropagation()}
-                      >
-                        <div className="flex items-center justify-end gap-3">
-                          {clickable &&
-                            (navigatingId === r.id ? (
-                              <span
-                                style={{
-                                  display: 'inline-block',
-                                  width: 14,
-                                  height: 14,
-                                  border: '2px solid #e2e8f0',
-                                  borderTopColor: '#2957FF',
-                                  borderRadius: '50%',
-                                  animation: 'spin 0.75s linear infinite',
-                                  flexShrink: 0,
-                                }}
-                              />
-                            ) : (
-                              <span className="font-outfit text-xs font-semibold text-[#2957FF]">
-                                View →
-                              </span>
-                            ))}
-                          {isEmployee &&
-                            (confirmingId === r.id ? (
-                              <span className="flex items-center gap-2">
-                                <button
-                                  type="button"
-                                  onClick={() => handleDelete(r.id)}
-                                  disabled={deletingId === r.id}
-                                  className="font-outfit text-xs font-semibold text-red-600 hover:text-red-800 transition-colors disabled:opacity-50"
-                                >
-                                  {deletingId === r.id
-                                    ? 'Deleting…'
-                                    : 'Confirm'}
-                                </button>
-                                <button
-                                  type="button"
-                                  onClick={() => setConfirmingId(null)}
-                                  className="font-outfit text-xs text-gray-400 hover:text-gray-600 transition-colors"
-                                >
-                                  Cancel
-                                </button>
-                              </span>
-                            ) : (
-                              <button
-                                type="button"
-                                onClick={() => setConfirmingId(r.id)}
-                                className="text-gray-300 hover:text-red-500 transition-colors"
-                                title="Delete report"
-                              >
-                                <FaTrash size={13} />
-                              </button>
-                            ))}
-                        </div>
+                      <td className="font-outfit text-gray-400 px-6 py-4">
+                        {timeAgo(u.last_active)}
                       </td>
                     </tr>
-                  )
-                })}
+                  ))
+                )}
               </tbody>
             </table>
+          </div>
+        )}
+
+        {/* Activity tab */}
+        {isEmployee && activeTab === 'Activity' && (
+          <div className="bg-white rounded-2xl border border-gray-100 shadow-sm overflow-hidden">
+            {recentEvents.length === 0 ? (
+              <p className="font-outfit text-gray-400 text-sm text-center px-6 py-12">
+                No activity recorded yet.
+              </p>
+            ) : (
+              <ul className="divide-y divide-gray-50">
+                {recentEvents.map((e, i) => (
+                  <li key={i} className="flex items-center gap-4 px-6 py-3.5">
+                    <span
+                      className={`w-2 h-2 rounded-full flex-shrink-0 ${
+                        EVENT_COLORS[e.type] ?? 'bg-gray-300'
+                      }`}
+                    />
+                    <span className="font-outfit text-sm text-[#2C2C2C] flex-1 min-w-0">
+                      <span className="font-medium">{e.user_email}</span>{' '}
+                      <span className="text-gray-500">
+                        {EVENT_LABELS[e.type] ?? e.type}
+                      </span>
+                    </span>
+                    <span className="font-outfit text-xs text-gray-400 flex-shrink-0">
+                      {timeAgo(e.created_at)}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
           </div>
         )}
       </div>

--- a/pages/dashboard.jsx
+++ b/pages/dashboard.jsx
@@ -99,6 +99,13 @@ export async function getServerSideProps({ req, res }) {
 
   const { data: reports } = await query
 
+  const oneWeekAgoIso = new Date(
+    Date.now() - 7 * 24 * 60 * 60 * 1000,
+  ).toISOString()
+  const reportsThisWeek = (reports ?? []).filter(
+    (r) => r.created_at >= oneWeekAgoIso,
+  ).length
+
   if (!isEmployee) {
     return {
       props: {
@@ -108,6 +115,7 @@ export async function getServerSideProps({ req, res }) {
         },
         isEmployee,
         reports: reports ?? [],
+        reportsThisWeek,
         users: [],
         recentEvents: [],
       },
@@ -160,6 +168,7 @@ export async function getServerSideProps({ req, res }) {
       isEmployee,
       userId: user.id,
       reports: reports ?? [],
+      reportsThisWeek,
       users: usersWithStats,
       recentEvents,
     },
@@ -171,6 +180,7 @@ export default function Dashboard({
   reports: initialReports,
   isEmployee,
   userId,
+  reportsThisWeek,
   users,
   recentEvents,
 }) {
@@ -206,13 +216,6 @@ export default function Dashboard({
       setConfirmingId(null)
     }
   }
-
-  const oneWeekAgo = new Date(
-    Date.now() - 7 * 24 * 60 * 60 * 1000,
-  ).toISOString()
-  const reportsThisWeek = reports.filter(
-    (r) => r.created_at >= oneWeekAgo,
-  ).length
 
   return (
     <div className="rebranding-landing-page min-h-screen -mt-[12px]">
@@ -436,7 +439,7 @@ export default function Dashboard({
                     Joined
                   </th>
                   <th className="font-outfit font-semibold text-[11px] uppercase tracking-wider text-gray-400 text-left px-6 py-3.5">
-                    Last Active
+                    Recent Activity
                   </th>
                 </tr>
               </thead>
@@ -498,8 +501,11 @@ export default function Dashboard({
               </p>
             ) : (
               <ul className="divide-y divide-gray-50">
-                {recentEvents.map((e, i) => (
-                  <li key={i} className="flex items-center gap-4 px-6 py-3.5">
+                {recentEvents.map((e) => (
+                  <li
+                    key={`${e.user_id}-${e.created_at}-${e.type}`}
+                    className="flex items-center gap-4 px-6 py-3.5"
+                  >
                     <span
                       className={`w-2 h-2 rounded-full flex-shrink-0 ${
                         EVENT_COLORS[e.type] ?? 'bg-gray-300'

--- a/src/layout/MainHeader/index.jsx
+++ b/src/layout/MainHeader/index.jsx
@@ -1,12 +1,13 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import Image from 'next/legacy/image'
 import Link from 'next/link'
 import Logo from '../../assets/rebranding/logo_black.svg'
 import { scrollToSection } from '../../utilities/helpers'
 import MainHeaderMobile from './MainHeaderMobile'
-import { useRouter } from 'next/navigation'
+import { useRouter, usePathname } from 'next/navigation'
 import styles from './styles.module.css'
 import { WaitlistModal } from '../../components/MainLandingPage/OurGuarantee/WaitlistModal'
+import { createClient } from '../../lib/supabase-browser'
 
 const BUTTONS = [
   {
@@ -49,6 +50,19 @@ export default function MainHeader() {
   const navigate = (path) => {
     router.push(path)
   }
+  const pathname = usePathname()
+  const isRoiPage =
+    pathname === '/roi-report' || pathname?.startsWith('/report/')
+  const [isClient, setIsClient] = useState(false)
+  const [isEmployee, setIsEmployee] = useState(false)
+  useEffect(() => {
+    const supabase = createClient()
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      const employee = user?.email?.endsWith('@lyrise.ai') ?? false
+      setIsClient(!!user && !employee)
+      setIsEmployee(employee)
+    })
+  }, [])
   return (
     <header className="py-4 mt-3 px-2 sm:px-10  mb-10 lg:mb-0">
       <div
@@ -87,7 +101,23 @@ export default function MainHeader() {
           ))}
         </ul>
 
-        <div className="hidden lg:block">
+        <div className="hidden lg:flex items-center gap-4">
+          {isClient && isRoiPage && (
+            <Link
+              href="/dashboard"
+              className="font-outfit text-[16px] font-[600] text-new-black hover:opacity-70 transition-opacity"
+            >
+              My Reports
+            </Link>
+          )}
+          {isEmployee && isRoiPage && (
+            <Link
+              href="/dashboard"
+              className="font-outfit text-[16px] font-[600] text-new-black hover:opacity-70 transition-opacity"
+            >
+              ← Dashboard
+            </Link>
+          )}
           {BUTTONS.map(({ label, path }) => (
             <WaitlistModal>
               <div


### PR DESCRIPTION
### **Setup user activity tracking and admin dashboard**

1. **Event collection**

- Added `report_viewed` event write to `GET /api/reports/[id]` — fires every time a user opens a report
- Added `report_created` event write to `/api/roi-agent `— fires when a report finishes generating
- Added `chat_message_sent` event write to `/api/roi-agent` — fires after each chat reply
- All events are written to the existing events table in Supabase (fire-and-forget, no impact on response time).

2. **Admin dashboard (/dashboard)**

- Renamed to "Admin Dashboard" for employees
- Added 3 stat cards: Total Users, Total Reports, Reports This Week
- Added tab switcher: Reports | My Reports | Users | Activity
- Reports — all reports across all users (existing behavior)
- My Reports — filtered to the admin's own reports
- Users — table showing each user's email, role, report count, join date, and last active time
- Activity — live feed of the last 50 events with color-coded dots and timestamps
- Navigation improvements

3. **Added `"My Reports"` link** in the header for client users — only visible on `/roi-report` and `/report/* `pages, links to their dashboard
4. **Added `"← Dashboard"` link** in the header for admin users — only visible on `/roi-report `and `/report/*` pages, links back to the admin dashboard