### PR TITLE
fix(bulk): abort agent on client disconnect, show true requester

### DIFF
--- a/pages/api/roi-agent.js
+++ b/pages/api/roi-agent.js
@@ -35,6 +35,8 @@ export const config = {
 const IS_DEV = process.env.NODE_ENV === 'development'
 
 function send(res, event) {
+  // Once the connection is closed, writing throws (EPIPE) — silently drop.
+  if (res.writableEnded || res.destroyed) return
   res.write(`data: ${JSON.stringify(event)}\n\n`)
   if (typeof res.flush === 'function') res.flush()
 }
@@ -237,6 +239,22 @@ export default async function handler(req, res) {
   res.setHeader('Connection', 'keep-alive')
   res.setHeader('X-Accel-Buffering', 'no')
 
+  // ── Client-disconnect handling ─────────────────────────────────────────────
+  // If the browser tab closes, navigates away, or the landing page crashes
+  // mid-stream, the underlying connection drops. Without this the agent keeps
+  // burning tokens and still fires the PDF/email side effects for a report
+  // nobody is waiting on. Abort the agent loop and skip the email when the
+  // client goes away — already-saved reports stay accessible from the
+  // dashboard, and an employee can still email them manually.
+  const abortController = new AbortController()
+  let clientDisconnected = false
+  res.on('close', () => {
+    if (res.writableEnded) return // normal completion, not a disconnect
+    clientDisconnected = true
+    abortController.abort()
+    console.warn('[roi-agent] client disconnected — aborting agent run')
+  })
+
   try {
     const execTemplateHtml = loadTemplate('roi-exec-template.html')
     const fullTemplateHtml = loadTemplate('roi-template.html')
@@ -298,6 +316,7 @@ export default async function handler(req, res) {
       templateHtml: execTemplateHtml,
       fullTemplateHtml,
       estimatesOnly: Boolean(devOptions?.estimatesOnly),
+      abortSignal: abortController.signal,
       callbacks: {
         onTextDelta: (delta) => send(res, { type: 'text_delta', delta }),
         onToolStart: (tool) => send(res, { type: 'tool_start', tool }),
@@ -468,9 +487,18 @@ export default async function handler(req, res) {
       }
     }
 
-    // Fire-and-forget PDF + email after generation
+    // Fire-and-forget PDF + email after generation.
+    // Skip when the client has disconnected: the report is still saved above
+    // and reachable from the dashboard, but we don't auto-email a company a
+    // report whose request was abandoned.
+    if (clientDisconnected && mode === 'generate' && state.assembled) {
+      console.warn(
+        '[roi-agent] client gone — report saved but skipping PDF/email',
+      )
+    }
     if (
       !IS_DEV &&
+      !clientDisconnected &&
       mode === 'generate' &&
       state.assembled &&
       state.renderedHtml &&

--- a/pages/dashboard.jsx
+++ b/pages/dashboard.jsx
@@ -55,14 +55,23 @@ function RoleBadge({ role }) {
   )
 }
 
-// Tags each report with the requesting user's role. Only @lyrise.ai addresses
-// count as employees; everyone else (including external client domains) is a
-// client, regardless of how their account role is stored.
-function withRequesterRole(reports) {
-  return (reports ?? []).map((r) => ({
-    ...r,
-    requester_role: r.email?.endsWith('@lyrise.ai') ? 'EMPLOYEE' : 'CLIENT',
-  }))
+// Tags each report with the email + role of the user who actually requested
+// it. The requester is the authenticated account that submitted the request
+// (resolved via user_id) — for bulk uploads that is the LyRise employee who
+// uploaded the CSV, NOT the company contact in reports.email the report is
+// addressed to. Showing reports.email here made employee bulk runs look like
+// self-service client requests. Only @lyrise.ai addresses count as employees.
+function withRequester(reports, requesterEmailFor) {
+  return (reports ?? []).map((r) => {
+    const requesterEmail = requesterEmailFor(r) ?? r.email ?? null
+    return {
+      ...r,
+      requester_email: requesterEmail,
+      requester_role: requesterEmail?.endsWith('@lyrise.ai')
+        ? 'EMPLOYEE'
+        : 'CLIENT',
+    }
+  })
 }
 
 function formatDate(iso) {
@@ -137,7 +146,7 @@ export async function getServerSideProps({ req, res }) {
           name: user.user_metadata?.full_name ?? null,
         },
         isEmployee,
-        reports: withRequesterRole(reports),
+        reports: withRequester(reports, () => user.email),
         reportsThisWeek,
         users: [],
         recentEvents: [],
@@ -190,7 +199,7 @@ export async function getServerSideProps({ req, res }) {
       user: { email: user.email, name: user.user_metadata?.full_name ?? null },
       isEmployee,
       userId: user.id,
-      reports: withRequesterRole(reports),
+      reports: withRequester(reports, (r) => userEmailById[r.user_id]),
       reportsThisWeek,
       users: usersWithStats,
       recentEvents,
@@ -383,7 +392,7 @@ export default function Dashboard({
                             {r.company_name || '—'}
                           </td>
                           <td className="font-outfit text-gray-500 px-6 py-4">
-                            {r.email || '—'}
+                            {r.requester_email || '—'}
                           </td>
                           <td className="px-6 py-4">
                             <RoleBadge role={r.requester_role} />

--- a/src/lib/roi/agent.ts
+++ b/src/lib/roi/agent.ts
@@ -1856,6 +1856,9 @@ export async function runReportAgent(params: {
   templateHtml: string
   fullTemplateHtml: string
   estimatesOnly?: boolean
+  // Aborts the streamText loop when the caller (e.g. an HTTP client) goes away,
+  // so we stop burning tokens on a report nobody is waiting on.
+  abortSignal?: AbortSignal
 }): Promise<void> {
   const {
     mode,
@@ -1866,6 +1869,7 @@ export async function runReportAgent(params: {
     templateHtml,
     fullTemplateHtml,
     estimatesOnly = false,
+    abortSignal,
   } = params
 
   const company = state.normInput?.companyName ?? 'unknown'
@@ -1947,21 +1951,36 @@ ${
     messages,
     tools,
     stopWhen: stepCountIs(mode === 'generate' ? 24 : 8),
+    abortSignal,
   })
 
-  for await (const part of result.fullStream) {
-    if (part.type === 'text-delta') {
-      callbacks.onTextDelta(part.text)
-    } else if (part.type === 'tool-call') {
-      callbacks.onToolStart(part.toolName)
-    } else if (part.type === 'error') {
-      callbacks.onError(
-        part.error instanceof Error
-          ? part.error
-          : new Error(String(part.error)),
-      )
+  try {
+    for await (const part of result.fullStream) {
+      if (part.type === 'text-delta') {
+        callbacks.onTextDelta(part.text)
+      } else if (part.type === 'tool-call') {
+        callbacks.onToolStart(part.toolName)
+      } else if (part.type === 'error') {
+        // An abort surfaces here as an error part — treat it as a clean stop,
+        // not a generation failure, so the caller doesn't persist/email it.
+        if (abortSignal?.aborted) {
+          roiWarn('agent', '⏹ runReportAgent aborted — caller disconnected')
+          return
+        }
+        callbacks.onError(
+          part.error instanceof Error
+            ? part.error
+            : new Error(String(part.error)),
+        )
+        return
+      }
+    }
+  } catch (err) {
+    if (abortSignal?.aborted) {
+      roiWarn('agent', '⏹ runReportAgent aborted — caller disconnected')
       return
     }
+    throw err
   }
 
   const response = await result.response


### PR DESCRIPTION
When the landing page crashed or the user left, per-row roi-agent requests dropped their connections but the server kept running the LLM agent and still emailed reports nobody was waiting on.

- runReportAgent accepts an abortSignal, passes it to streamText, and treats an abort as a clean stop (no onError/onDone) so callers don't persist or email a partial run.
- /api/roi-agent aborts the agent on res "close" and skips the PDF/email side effects when the client is gone. Already-saved reports stay reachable from the dashboard.

Also fix the dashboard "Requested By" column: it showed reports.email (the company contact) instead of the authenticated requester, making employee bulk uploads look like self-service client requests. It now resolves the requester from user_id.