### PR TITLE
Add roi_usage monitoring

### DIFF
--- a/pages/api/roi-agent.js
+++ b/pages/api/roi-agent.js
@@ -28,6 +28,7 @@ import {
   splitStoredState,
 } from '@/src/lib/roi/reportState'
 import { persistReportEvidence } from '@/src/lib/roi/reportEvidence'
+import { persistUsage } from '@/src/lib/roi/services/usageStore'
 import { assessReportSpecificity } from '@/src/lib/roi/specificity'
 
 export const config = {
@@ -388,6 +389,7 @@ export default async function handler(req, res) {
     }
 
     let capturedMessages = []
+    let capturedUsage = null
 
     await runReportAgent({
       mode,
@@ -420,6 +422,9 @@ export default async function handler(req, res) {
             messages,
           })
         },
+        onUsage: (summary) => {
+          capturedUsage = summary
+        },
         onError: (err) => send(res, { type: 'error', message: err.message }),
       },
     })
@@ -427,6 +432,15 @@ export default async function handler(req, res) {
     if (mode === 'chat' && reportId) {
       const userRole = chatUserRole
       state.specificityAssessment = assessReportSpecificity(state)
+
+      // Persist LLM usage for this chat turn (report already exists). upsert on
+      // report_id keeps one usage row per report. Fire-and-forget.
+      if (capturedUsage) {
+        persistUsage(capturedUsage, {
+          reportId,
+          userId: persistedReport?.user_id ?? user.id,
+        }).catch((e) => console.error('[roi-usage] persist failed', e))
+      }
 
       // chat_messages.user_id is FK to auth.users. For share-link visitors
       // (no session) we attribute writes to the report owner so the FK
@@ -581,6 +595,14 @@ export default async function handler(req, res) {
 
       if (savedReport?.id) {
         savedReportId = savedReport.id
+        // Persist LLM usage now that the report row (report_id) exists.
+        // Fire-and-forget: monitoring must never block or fail generation.
+        if (capturedUsage) {
+          persistUsage(capturedUsage, {
+            reportId: savedReport.id,
+            userId: user.id,
+          }).catch((e) => console.error('[roi-usage] persist failed', e))
+        }
         await persistReportEvidence(
           adminSupabase,
           savedReport.id,

--- a/pages/api/track/share-event.js
+++ b/pages/api/track/share-event.js
@@ -1,0 +1,84 @@
+import { createAdminClient } from '../../../src/lib/supabase-server'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /api/track/share-event
+//   body: { reportId, shareToken, type, durationMs? }
+//
+// Records behaviour events for SHARE-LINK RECIPIENTS (the email prospects who
+// open "Edit with chat"). These visitors have no Supabase session, so auth is
+// the share token itself: we only accept an event if (reportId, shareToken)
+// matches a live, non-revoked share link. That prevents spoofing events onto
+// arbitrary reports.
+//
+// Writes to the existing `events` table (same shape as report_viewed etc.),
+// with user_id = NULL since the recipient is anonymous. durationMs (for chat
+// session length) is stored in events.meta if that column exists; otherwise it
+// is silently dropped so this never fails on a missing column.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Only these types may be written through this anonymous endpoint.
+const ALLOWED_TYPES = new Set([
+  'chat_link_opened', // recipient clicked "Edit with chat" and landed on the page
+  'chat_session_end', // recipient left — carries durationMs (time in the panel)
+  'pdf_downloaded_share', // recipient downloaded the PDF from the share view
+])
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const { reportId, shareToken, type, durationMs } = req.body ?? {}
+
+  if (!reportId || !shareToken || !type) {
+    return res
+      .status(400)
+      .json({ error: 'reportId, shareToken and type are required' })
+  }
+  if (!ALLOWED_TYPES.has(type)) {
+    return res.status(400).json({ error: 'unknown event type' })
+  }
+
+  const admin = createAdminClient()
+
+  // Validate the share token against the report (the only "auth" here).
+  const { data: report } = await admin
+    .from('reports')
+    .select('id, share_token, share_revoked_at')
+    .eq('id', reportId)
+    .single()
+
+  const tokenValid =
+    report &&
+    report.share_token &&
+    report.share_token === shareToken &&
+    !report.share_revoked_at
+
+  if (!tokenValid) {
+    return res.status(403).json({ error: 'Invalid share link' })
+  }
+
+  // Build the row. Try to attach duration in a `meta` JSONB column; if the
+  // column doesn't exist, retry without it so tracking never blocks on schema.
+  const baseRow = { user_id: null, report_id: reportId, type }
+  const meta =
+    typeof durationMs === 'number' && durationMs >= 0 ? { durationMs } : null
+
+  let insertError = null
+  if (meta) {
+    const { error } = await admin.from('events').insert({ ...baseRow, meta })
+    insertError = error
+  }
+  if (!meta || insertError) {
+    const { error } = await admin.from('events').insert(baseRow)
+    insertError = error
+  }
+
+  if (insertError) {
+    // Non-fatal: tracking must never surface as a user-facing error.
+    console.error('[track/share-event] insert failed', insertError.message)
+    return res.status(200).json({ ok: false })
+  }
+
+  return res.status(200).json({ ok: true })
+}

--- a/pages/api/track/share-event.js
+++ b/pages/api/track/share-event.js
@@ -12,8 +12,8 @@ import { createAdminClient } from '../../../src/lib/supabase-server'
 //
 // Writes to the existing `events` table (same shape as report_viewed etc.),
 // with user_id = NULL since the recipient is anonymous. durationMs (for chat
-// session length) is stored in events.meta if that column exists; otherwise it
-// is silently dropped so this never fails on a missing column.
+// session length) is stored in the events.meta JSONB column added by migration
+// 20260603_000006_events_meta.
 // ─────────────────────────────────────────────────────────────────────────────
 
 // Only these types may be written through this anonymous endpoint.
@@ -58,21 +58,15 @@ export default async function handler(req, res) {
     return res.status(403).json({ error: 'Invalid share link' })
   }
 
-  // Build the row. Try to attach duration in a `meta` JSONB column; if the
-  // column doesn't exist, retry without it so tracking never blocks on schema.
-  const baseRow = { user_id: null, report_id: reportId, type }
-  const meta =
-    typeof durationMs === 'number' && durationMs >= 0 ? { durationMs } : null
+  // Build the row. Attach duration in the `meta` JSONB column when present
+  // (added by migration 20260603_000006_events_meta). A single insert avoids
+  // the risk of double-writing an event if a transient error triggered a retry.
+  const row = { user_id: null, report_id: reportId, type }
+  if (typeof durationMs === 'number' && durationMs >= 0) {
+    row.meta = { durationMs }
+  }
 
-  let insertError = null
-  if (meta) {
-    const { error } = await admin.from('events').insert({ ...baseRow, meta })
-    insertError = error
-  }
-  if (!meta || insertError) {
-    const { error } = await admin.from('events').insert(baseRow)
-    insertError = error
-  }
+  const { error: insertError } = await admin.from('events').insert(row)
 
   if (insertError) {
     // Non-fatal: tracking must never surface as a user-facing error.

--- a/pages/api/usage/engagement.js
+++ b/pages/api/usage/engagement.js
@@ -1,0 +1,158 @@
+import {
+  createClient,
+  createAdminClient,
+} from '../../../src/lib/supabase-server'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/usage/engagement?days=30
+//
+// Employee-gated. Aggregates SHARE-LINK RECIPIENT behaviour from the `events`
+// table (chat_link_opened, chat_session_end, pdf_downloaded_share) plus the
+// existing chat_message_sent_share. Answers: who opened "Edit with chat", how
+// long they spent in the panel, whether they downloaded the PDF.
+//
+// Joins report company/email for readability. Session duration comes from
+// chat_session_end.meta.durationMs when present, else is derived from the gap
+// between the open and end timestamps.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const SHARE_TYPES = [
+  'chat_link_opened',
+  'chat_session_end',
+  'pdf_downloaded_share',
+  'chat_message_sent_share',
+]
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const supabase = createClient(req, res)
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  if (!user) return res.status(401).json({ error: 'Unauthorized' })
+
+  const admin = createAdminClient()
+  const { data: userData } = await admin
+    .from('users')
+    .select('role')
+    .eq('id', user.id)
+    .single()
+
+  const isEmployee =
+    userData?.role === 'EMPLOYEE' || user.email?.endsWith('@lyrise.ai')
+  if (!isEmployee) return res.status(403).json({ error: 'Forbidden' })
+
+  const days = Math.min(Math.max(parseInt(req.query.days, 10) || 30, 1), 365)
+  const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString()
+
+  const { data: events, error } = await admin
+    .from('events')
+    .select('id, report_id, type, created_at, meta')
+    .in('type', SHARE_TYPES)
+    .gte('created_at', since)
+    .order('created_at', { ascending: true })
+
+  if (error) {
+    return res
+      .status(200)
+      .json({ ready: false, error: error.message, totals: {}, perReport: [] })
+  }
+
+  const rows = events || []
+
+  // Look up company/email for the reports referenced, for readable rows.
+  const reportIds = [...new Set(rows.map((e) => e.report_id).filter(Boolean))]
+  let reportMap = new Map()
+  if (reportIds.length) {
+    const { data: reports } = await admin
+      .from('reports')
+      .select('id, company_name, email')
+      .in('id', reportIds)
+    reportMap = new Map((reports || []).map((r) => [r.id, r]))
+  }
+
+  // Group per report.
+  const perReportMap = new Map()
+  const ensure = (id) => {
+    if (!perReportMap.has(id)) {
+      const r = reportMap.get(id) || {}
+      perReportMap.set(id, {
+        reportId: id,
+        company: r.company_name || '—',
+        email: r.email || '—',
+        opens: 0,
+        downloads: 0,
+        chatMessages: 0,
+        totalDurationMs: 0,
+        sessions: 0,
+        lastActivity: null,
+        // Track the latest open without an end, to derive duration if needed.
+        pendingOpenAt: null,
+      })
+    }
+    return perReportMap.get(id)
+  }
+
+  rows.forEach((e) => {
+    if (!e.report_id) return
+    const r = ensure(e.report_id)
+    r.lastActivity = e.created_at
+
+    if (e.type === 'chat_link_opened') {
+      r.opens += 1
+      r.pendingOpenAt = e.created_at
+    } else if (e.type === 'pdf_downloaded_share') {
+      r.downloads += 1
+    } else if (e.type === 'chat_message_sent_share') {
+      r.chatMessages += 1
+    } else if (e.type === 'chat_session_end') {
+      r.sessions += 1
+      let dur =
+        e.meta && typeof e.meta.durationMs === 'number'
+          ? e.meta.durationMs
+          : null
+      if (dur == null && r.pendingOpenAt) {
+        dur =
+          new Date(e.created_at).getTime() - new Date(r.pendingOpenAt).getTime()
+      }
+      if (typeof dur === 'number' && dur > 0) r.totalDurationMs += dur
+      r.pendingOpenAt = null
+    }
+  })
+
+  const perReport = [...perReportMap.values()]
+    .map(({ pendingOpenAt, ...r }) => ({
+      ...r,
+      avgDurationMs: r.sessions
+        ? Math.round(r.totalDurationMs / r.sessions)
+        : 0,
+    }))
+    .sort((a, b) => (a.lastActivity < b.lastActivity ? 1 : -1))
+
+  const totals = perReport.reduce(
+    (acc, r) => ({
+      reportsOpened: acc.reportsOpened + (r.opens > 0 ? 1 : 0),
+      opens: acc.opens + r.opens,
+      downloads: acc.downloads + r.downloads,
+      chatMessages: acc.chatMessages + r.chatMessages,
+      totalDurationMs: acc.totalDurationMs + r.totalDurationMs,
+      sessions: acc.sessions + r.sessions,
+    }),
+    {
+      reportsOpened: 0,
+      opens: 0,
+      downloads: 0,
+      chatMessages: 0,
+      totalDurationMs: 0,
+      sessions: 0,
+    },
+  )
+  totals.avgDurationMs = totals.sessions
+    ? Math.round(totals.totalDurationMs / totals.sessions)
+    : 0
+
+  return res.status(200).json({ ready: true, totals, perReport })
+}

--- a/pages/api/usage/summary.js
+++ b/pages/api/usage/summary.js
@@ -1,0 +1,144 @@
+import {
+  createClient,
+  createAdminClient,
+} from '../../../src/lib/supabase-server'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/usage/summary?days=30
+//
+// Employee-gated. Returns aggregates for the monitoring dashboard:
+//   - totals (cost, reports, tokens, avg duration) over the window
+//   - perDay   : [{ day, costUsd, count }]            (cost & volume over time)
+//   - perModel : [{ model, costUsd, totalTokens, calls }]
+//   - perMode  : [{ mode, costUsd, count }]
+//   - recent   : last 50 rows (with per-call breakdown for the expandable table)
+//
+// All aggregation is done here (small data volumes) so the page stays a thin
+// renderer. Reads use the admin client; access is still gated by the employee
+// check below, mirroring pages/api/reports/[id].js.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const supabase = createClient(req, res)
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) return res.status(401).json({ error: 'Unauthorized' })
+
+  const admin = createAdminClient()
+
+  const { data: userData } = await admin
+    .from('users')
+    .select('role')
+    .eq('id', user.id)
+    .single()
+
+  const isEmployee =
+    userData?.role === 'EMPLOYEE' || user.email?.endsWith('@lyrise.ai')
+  if (!isEmployee) return res.status(403).json({ error: 'Forbidden' })
+
+  // Window: default last 30 days, clamped to [1, 365].
+  const days = Math.min(Math.max(parseInt(req.query.days, 10) || 30, 1), 365)
+  const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString()
+
+  const { data: rows, error } = await admin
+    .from('roi_usage')
+    .select(
+      'id, ts, company, mode, duration_ms, input_tokens, output_tokens, total_tokens, cost_usd, calls',
+    )
+    .gte('ts', since)
+    .order('ts', { ascending: false })
+
+  if (error) {
+    // Most likely the migration hasn't been applied yet — surface a clear,
+    // non-fatal signal the page can render as an empty/onboarding state.
+    return res.status(200).json({
+      ready: false,
+      error: error.message,
+      totals: emptyTotals(),
+      perDay: [],
+      perModel: [],
+      perMode: [],
+      recent: [],
+    })
+  }
+
+  const safeRows = rows || []
+
+  // ── Totals ─────────────────────────────────────────────────────────────────
+  const totals = safeRows.reduce(
+    (acc, r) => ({
+      reports: acc.reports + 1,
+      costUsd: acc.costUsd + Number(r.cost_usd || 0),
+      totalTokens: acc.totalTokens + (r.total_tokens || 0),
+      durationMs: acc.durationMs + (r.duration_ms || 0),
+    }),
+    { reports: 0, costUsd: 0, totalTokens: 0, durationMs: 0 },
+  )
+  totals.avgCostUsd = totals.reports ? totals.costUsd / totals.reports : 0
+  totals.avgDurationMs = totals.reports ? totals.durationMs / totals.reports : 0
+
+  // ── Per-day (cost + volume over time) ───────────────────────────────────────
+  const dayMap = new Map()
+  safeRows.forEach((r) => {
+    const day = (r.ts || '').slice(0, 10) // YYYY-MM-DD
+    const cur = dayMap.get(day) || { day, costUsd: 0, count: 0 }
+    cur.costUsd += Number(r.cost_usd || 0)
+    cur.count += 1
+    dayMap.set(day, cur)
+  })
+  const perDay = [...dayMap.values()].sort((a, b) => a.day.localeCompare(b.day))
+
+  // ── Per-model (rolled up from the per-call JSONB) ───────────────────────────
+  const modelMap = new Map()
+  safeRows.forEach((r) => {
+    ;(r.calls || []).forEach((c) => {
+      const cur = modelMap.get(c.model) || {
+        model: c.model,
+        costUsd: 0,
+        totalTokens: 0,
+        calls: 0,
+      }
+      cur.costUsd += Number(c.costUsd || 0)
+      cur.totalTokens += c.totalTokens || 0
+      cur.calls += 1
+      modelMap.set(c.model, cur)
+    })
+  })
+  const perModel = [...modelMap.values()].sort((a, b) => b.costUsd - a.costUsd)
+
+  // ── Per-mode (generate vs chat) ─────────────────────────────────────────────
+  const modeMap = new Map()
+  safeRows.forEach((r) => {
+    const cur = modeMap.get(r.mode) || { mode: r.mode, costUsd: 0, count: 0 }
+    cur.costUsd += Number(r.cost_usd || 0)
+    cur.count += 1
+    modeMap.set(r.mode, cur)
+  })
+  const perMode = [...modeMap.values()]
+
+  return res.status(200).json({
+    ready: true,
+    totals,
+    perDay,
+    perModel,
+    perMode,
+    recent: safeRows.slice(0, 50),
+  })
+}
+
+function emptyTotals() {
+  return {
+    reports: 0,
+    costUsd: 0,
+    totalTokens: 0,
+    durationMs: 0,
+    avgCostUsd: 0,
+    avgDurationMs: 0,
+  }
+}

--- a/pages/api/usage/summary.js
+++ b/pages/api/usage/summary.js
@@ -49,10 +49,10 @@ export default async function handler(req, res) {
   const { data: rows, error } = await admin
     .from('roi_usage')
     .select(
-      'id, ts, company, mode, duration_ms, input_tokens, output_tokens, total_tokens, cost_usd, calls',
+      'id, created_at, company, mode, duration_ms, input_tokens, output_tokens, total_tokens, cost_usd, calls',
     )
-    .gte('ts', since)
-    .order('ts', { ascending: false })
+    .gte('created_at', since)
+    .order('created_at', { ascending: false })
 
   if (error) {
     // Most likely the migration hasn't been applied yet — surface a clear,
@@ -86,7 +86,7 @@ export default async function handler(req, res) {
   // ── Per-day (cost + volume over time) ───────────────────────────────────────
   const dayMap = new Map()
   safeRows.forEach((r) => {
-    const day = (r.ts || '').slice(0, 10) // YYYY-MM-DD
+    const day = (r.created_at || '').slice(0, 10) // YYYY-MM-DD
     const cur = dayMap.get(day) || { day, costUsd: 0, count: 0 }
     cur.costUsd += Number(r.cost_usd || 0)
     cur.count += 1

--- a/pages/dashboard/usage.js
+++ b/pages/dashboard/usage.js
@@ -491,7 +491,7 @@ function ReportRow({ row }) {
             </IconButton>
           )}
         </TableCell>
-        <TableCell>{new Date(row.ts).toLocaleString()}</TableCell>
+        <TableCell>{new Date(row.created_at).toLocaleString()}</TableCell>
         <TableCell>{row.company || '—'}</TableCell>
         <TableCell>{row.mode}</TableCell>
         <TableCell align="right">{usd(row.cost_usd)}</TableCell>

--- a/pages/dashboard/usage.js
+++ b/pages/dashboard/usage.js
@@ -56,9 +56,20 @@ const usd = (n) => `$${Number(n || 0).toFixed(n >= 1 ? 2 : 4)}`
 const secs = (ms) => `${(Number(ms || 0) / 1000).toFixed(1)}s`
 const num = (n) => Number(n || 0).toLocaleString()
 
+// Human-friendly duration: "—" / "45s" / "3m 20s".
+const dur = (ms) => {
+  const total = Math.round(Number(ms || 0) / 1000)
+  if (!total) return '—'
+  if (total < 60) return `${total}s`
+  const m = Math.floor(total / 60)
+  const s = total % 60
+  return s ? `${m}m ${s}s` : `${m}m`
+}
+
 export default function UsageDashboard() {
   const [days, setDays] = useState(30)
   const [data, setData] = useState(null)
+  const [engagement, setEngagement] = useState(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState('')
 
@@ -66,15 +77,24 @@ export default function UsageDashboard() {
     let cancelled = false
     setLoading(true)
     setError('')
-    fetch(`/api/usage/summary?days=${days}`, { credentials: 'include' })
-      .then((r) => r.json())
-      .then((json) => {
+    Promise.all([
+      fetch(`/api/usage/summary?days=${days}`, {
+        credentials: 'include',
+      }).then((r) => r.json()),
+      fetch(`/api/usage/engagement?days=${days}`, {
+        credentials: 'include',
+      })
+        .then((r) => r.json())
+        .catch(() => null),
+    ])
+      .then(([summary, eng]) => {
         if (cancelled) return
-        if (json.error && !json.totals) {
-          setError(json.error)
+        if (summary.error && !summary.totals) {
+          setError(summary.error)
         } else {
-          setData(json)
+          setData(summary)
         }
+        setEngagement(eng)
       })
       .catch(() => !cancelled && setError('Failed to load usage data'))
       .finally(() => !cancelled && setLoading(false))
@@ -164,6 +184,10 @@ export default function UsageDashboard() {
 
         {!loading && !error && data && data.ready !== false && (
           <Dashboard data={data} />
+        )}
+
+        {!loading && !error && engagement && engagement.ready !== false && (
+          <EngagementPanel data={engagement} />
         )}
       </Box>
     </>
@@ -295,6 +319,96 @@ function Dashboard({ data }) {
         </CardContent>
       </Card>
     </>
+  )
+}
+
+// Recipient engagement: who opened "Edit with chat", time in panel, downloads.
+function EngagementPanel({ data }) {
+  const { totals, perReport } = data
+  return (
+    <Box sx={{ mt: 4 }}>
+      <Typography variant="h5" fontWeight={700} color="#1a1a2e" mb={0.5}>
+        Recipient engagement
+      </Typography>
+      <Typography variant="body2" color="text.secondary" mb={2}>
+        Activity from prospects who opened &quot;Edit with chat&quot; from the
+        emails
+      </Typography>
+
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: { xs: '1fr 1fr', md: 'repeat(4, 1fr)' },
+          gap: 2,
+          mb: 3,
+        }}
+      >
+        <StatCard
+          label="Reports opened"
+          value={num(totals.reportsOpened)}
+          accent="#16a34a"
+        />
+        <StatCard
+          label="Total opens"
+          value={num(totals.opens)}
+          accent="#0891b2"
+        />
+        <StatCard
+          label="Avg time in chat"
+          value={dur(totals.avgDurationMs)}
+          accent="#7c3aed"
+        />
+        <StatCard
+          label="PDF downloads"
+          value={num(totals.downloads)}
+          accent="#ea580c"
+        />
+      </Box>
+
+      <Card>
+        <CardContent>
+          <Typography fontWeight={600} mb={2}>
+            By report
+          </Typography>
+          {perReport.length === 0 ? (
+            <Typography variant="body2" color="text.secondary">
+              No recipient activity in this window yet.
+            </Typography>
+          ) : (
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Company</TableCell>
+                  <TableCell>Recipient</TableCell>
+                  <TableCell align="right">Opens</TableCell>
+                  <TableCell align="right">Avg time</TableCell>
+                  <TableCell align="right">Chat msgs</TableCell>
+                  <TableCell align="right">Downloads</TableCell>
+                  <TableCell align="right">Last activity</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {perReport.map((r) => (
+                  <TableRow key={r.reportId} hover>
+                    <TableCell>{r.company}</TableCell>
+                    <TableCell>{r.email}</TableCell>
+                    <TableCell align="right">{num(r.opens)}</TableCell>
+                    <TableCell align="right">{dur(r.avgDurationMs)}</TableCell>
+                    <TableCell align="right">{num(r.chatMessages)}</TableCell>
+                    <TableCell align="right">{num(r.downloads)}</TableCell>
+                    <TableCell align="right">
+                      {r.lastActivity
+                        ? new Date(r.lastActivity).toLocaleString()
+                        : '—'}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </Box>
   )
 }
 

--- a/pages/dashboard/usage.js
+++ b/pages/dashboard/usage.js
@@ -1,0 +1,421 @@
+import { useEffect, useState } from 'react'
+import Head from 'next/head'
+import {
+  Box,
+  Card,
+  CardContent,
+  Typography,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Collapse,
+  IconButton,
+  Select,
+  MenuItem,
+  CircularProgress,
+  Chip,
+} from '@mui/material'
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown'
+import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp'
+import { createRouteClient } from '../../src/lib/supabaseRouteClient'
+import { createAdminClient } from '../../src/lib/supabase-server'
+
+// ── Server-side employee gate ─────────────────────────────────────────────────
+// Non-employees never receive the page (redirected to login). Mirrors the auth
+// pattern in pages/auth/login.js + the employee check in pages/api/reports/[id].
+export async function getServerSideProps({ req, res }) {
+  const supabase = createRouteClient(req, res)
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    return { redirect: { destination: '/auth/login', permanent: false } }
+  }
+
+  const admin = createAdminClient()
+  const { data: userData } = await admin
+    .from('users')
+    .select('role')
+    .eq('id', user.id)
+    .single()
+
+  const isEmployee =
+    userData?.role === 'EMPLOYEE' || user.email?.endsWith('@lyrise.ai')
+  if (!isEmployee) {
+    return { redirect: { destination: '/', permanent: false } }
+  }
+
+  return { props: {} }
+}
+
+// ── Formatting helpers ────────────────────────────────────────────────────────
+const usd = (n) => `$${Number(n || 0).toFixed(n >= 1 ? 2 : 4)}`
+const secs = (ms) => `${(Number(ms || 0) / 1000).toFixed(1)}s`
+const num = (n) => Number(n || 0).toLocaleString()
+
+export default function UsageDashboard() {
+  const [days, setDays] = useState(30)
+  const [data, setData] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    setError('')
+    fetch(`/api/usage/summary?days=${days}`, { credentials: 'include' })
+      .then((r) => r.json())
+      .then((json) => {
+        if (cancelled) return
+        if (json.error && !json.totals) {
+          setError(json.error)
+        } else {
+          setData(json)
+        }
+      })
+      .catch(() => !cancelled && setError('Failed to load usage data'))
+      .finally(() => !cancelled && setLoading(false))
+    return () => {
+      cancelled = true
+    }
+  }, [days])
+
+  return (
+    <>
+      <Head>
+        <title>Usage Monitoring | LyRise</title>
+      </Head>
+      <Box
+        sx={{
+          minHeight: '100vh',
+          bgcolor: '#f6f7fb',
+          p: { xs: 2, md: 4 },
+          fontFamily: 'inherit',
+        }}
+      >
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            mb: 3,
+            flexWrap: 'wrap',
+            gap: 2,
+          }}
+        >
+          <Box>
+            <Typography variant="h4" fontWeight={700} color="#1a1a2e">
+              Usage Monitoring
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              LLM cost &amp; time per report
+            </Typography>
+          </Box>
+          <Select
+            size="small"
+            value={days}
+            onChange={(e) => setDays(e.target.value)}
+            sx={{ bgcolor: '#fff', minWidth: 140 }}
+          >
+            <MenuItem value={7}>Last 7 days</MenuItem>
+            <MenuItem value={30}>Last 30 days</MenuItem>
+            <MenuItem value={90}>Last 90 days</MenuItem>
+            <MenuItem value={365}>Last year</MenuItem>
+          </Select>
+        </Box>
+
+        {loading && (
+          <Box sx={{ display: 'flex', justifyContent: 'center', py: 10 }}>
+            <CircularProgress />
+          </Box>
+        )}
+
+        {!loading && error && (
+          <Card sx={{ p: 3, bgcolor: '#fff7ed', border: '1px solid #fed7aa' }}>
+            <Typography fontWeight={600} color="#9a3412">
+              Could not load usage data
+            </Typography>
+            <Typography variant="body2" color="#9a3412" sx={{ mt: 1 }}>
+              {error}
+            </Typography>
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+              If the <code>roi_usage</code> table doesn&apos;t exist yet, apply
+              the migration <code>20260603_000005_roi_usage.sql</code> and
+              reload.
+            </Typography>
+          </Card>
+        )}
+
+        {!loading && !error && data && data.ready === false && (
+          <Card sx={{ p: 3, bgcolor: '#eff6ff', border: '1px solid #bfdbfe' }}>
+            <Typography fontWeight={600} color="#1e40af">
+              Waiting for the database
+            </Typography>
+            <Typography variant="body2" color="#1e40af" sx={{ mt: 1 }}>
+              The <code>roi_usage</code> table isn&apos;t available yet. Once
+              the migration is applied, generated reports will start appearing
+              here.
+            </Typography>
+          </Card>
+        )}
+
+        {!loading && !error && data && data.ready !== false && (
+          <Dashboard data={data} />
+        )}
+      </Box>
+    </>
+  )
+}
+
+function Dashboard({ data }) {
+  const { totals, perDay, perModel, perMode, recent } = data
+
+  if (!totals.reports) {
+    return (
+      <Card sx={{ p: 4, textAlign: 'center' }}>
+        <Typography color="text.secondary">
+          No reports recorded in this window yet.
+        </Typography>
+      </Card>
+    )
+  }
+
+  return (
+    <>
+      {/* Summary cards */}
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: { xs: '1fr 1fr', md: 'repeat(4, 1fr)' },
+          gap: 2,
+          mb: 3,
+        }}
+      >
+        <StatCard
+          label="Total cost"
+          value={usd(totals.costUsd)}
+          accent="#2957FF"
+        />
+        <StatCard
+          label="Reports"
+          value={num(totals.reports)}
+          accent="#7c3aed"
+        />
+        <StatCard
+          label="Avg cost / report"
+          value={usd(totals.avgCostUsd)}
+          accent="#0891b2"
+        />
+        <StatCard
+          label="Avg duration"
+          value={secs(totals.avgDurationMs)}
+          accent="#ea580c"
+        />
+      </Box>
+
+      {/* Charts row */}
+      <Box
+        sx={{
+          display: 'grid',
+          gridTemplateColumns: { xs: '1fr', md: '2fr 1fr' },
+          gap: 2,
+          mb: 3,
+        }}
+      >
+        <Card>
+          <CardContent>
+            <Typography fontWeight={600} mb={2}>
+              Cost over time
+            </Typography>
+            <BarChart
+              items={perDay.map((d) => ({
+                label: d.day.slice(5), // MM-DD
+                value: d.costUsd,
+                caption: `${usd(d.costUsd)} · ${d.count} rpt`,
+              }))}
+              color="#2957FF"
+            />
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent>
+            <Typography fontWeight={600} mb={2}>
+              Cost by model
+            </Typography>
+            <BarChart
+              items={perModel.map((m) => ({
+                label: m.model,
+                value: m.costUsd,
+                caption: `${usd(m.costUsd)} · ${num(m.totalTokens)} tok`,
+              }))}
+              color="#7c3aed"
+            />
+          </CardContent>
+        </Card>
+      </Box>
+
+      {/* Mode breakdown chips */}
+      <Box sx={{ display: 'flex', gap: 1, mb: 3, flexWrap: 'wrap' }}>
+        {perMode.map((m) => (
+          <Chip
+            key={m.mode}
+            label={`${m.mode}: ${usd(m.costUsd)} (${m.count})`}
+            sx={{ bgcolor: '#fff', border: '1px solid #e5e7eb' }}
+          />
+        ))}
+      </Box>
+
+      {/* Recent reports table */}
+      <Card>
+        <CardContent>
+          <Typography fontWeight={600} mb={2}>
+            Recent reports
+          </Typography>
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell />
+                <TableCell>When</TableCell>
+                <TableCell>Company</TableCell>
+                <TableCell>Mode</TableCell>
+                <TableCell align="right">Cost</TableCell>
+                <TableCell align="right">Duration</TableCell>
+                <TableCell align="right">Tokens</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {recent.map((r) => (
+                <ReportRow key={r.id} row={r} />
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </>
+  )
+}
+
+function StatCard({ label, value, accent }) {
+  return (
+    <Card sx={{ borderTop: `3px solid ${accent}` }}>
+      <CardContent>
+        <Typography variant="body2" color="text.secondary">
+          {label}
+        </Typography>
+        <Typography variant="h5" fontWeight={700} sx={{ mt: 0.5 }}>
+          {value}
+        </Typography>
+      </CardContent>
+    </Card>
+  )
+}
+
+// Lightweight horizontal bar chart — no chart dependency, just MUI Box.
+function BarChart({ items, color }) {
+  if (!items.length) {
+    return (
+      <Typography variant="body2" color="text.secondary">
+        No data
+      </Typography>
+    )
+  }
+  const max = Math.max(...items.map((i) => i.value), 0.000001)
+  return (
+    <Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>
+      {items.map((i, idx) => (
+        <Box key={`${i.label}-${idx}`}>
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              mb: 0.25,
+            }}
+          >
+            <Typography variant="caption" color="text.secondary" noWrap>
+              {i.label}
+            </Typography>
+            <Typography variant="caption" color="text.secondary">
+              {i.caption}
+            </Typography>
+          </Box>
+          <Box
+            sx={{
+              height: 8,
+              borderRadius: 4,
+              bgcolor: '#eef0f5',
+              overflow: 'hidden',
+            }}
+          >
+            <Box
+              sx={{
+                height: '100%',
+                width: `${Math.max((i.value / max) * 100, 2)}%`,
+                bgcolor: color,
+                borderRadius: 4,
+              }}
+            />
+          </Box>
+        </Box>
+      ))}
+    </Box>
+  )
+}
+
+function ReportRow({ row }) {
+  const [open, setOpen] = useState(false)
+  const calls = row.calls || []
+  return (
+    <>
+      <TableRow hover>
+        <TableCell sx={{ width: 40 }}>
+          {calls.length > 0 && (
+            <IconButton size="small" onClick={() => setOpen((o) => !o)}>
+              {open ? <KeyboardArrowUpIcon /> : <KeyboardArrowDownIcon />}
+            </IconButton>
+          )}
+        </TableCell>
+        <TableCell>{new Date(row.ts).toLocaleString()}</TableCell>
+        <TableCell>{row.company || '—'}</TableCell>
+        <TableCell>{row.mode}</TableCell>
+        <TableCell align="right">{usd(row.cost_usd)}</TableCell>
+        <TableCell align="right">{secs(row.duration_ms)}</TableCell>
+        <TableCell align="right">{num(row.total_tokens)}</TableCell>
+      </TableRow>
+      <TableRow>
+        <TableCell sx={{ py: 0, border: 0 }} colSpan={7}>
+          <Collapse in={open} timeout="auto" unmountOnExit>
+            <Box sx={{ my: 1, ml: 5 }}>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Step</TableCell>
+                    <TableCell>Model</TableCell>
+                    <TableCell align="right">Input</TableCell>
+                    <TableCell align="right">Output</TableCell>
+                    <TableCell align="right">Total</TableCell>
+                    <TableCell align="right">Cost</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {calls.map((c, i) => (
+                    <TableRow key={`${c.call}-${i}`}>
+                      <TableCell>{c.call}</TableCell>
+                      <TableCell>{c.model}</TableCell>
+                      <TableCell align="right">{num(c.inputTokens)}</TableCell>
+                      <TableCell align="right">{num(c.outputTokens)}</TableCell>
+                      <TableCell align="right">{num(c.totalTokens)}</TableCell>
+                      <TableCell align="right">{usd(c.costUsd)}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </Box>
+          </Collapse>
+        </TableCell>
+      </TableRow>
+    </>
+  )
+}

--- a/src/components/ROIGenerator/ReportViewer.jsx
+++ b/src/components/ROIGenerator/ReportViewer.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useCallback, useEffect } from 'react'
 import Link from 'next/link'
 import { drainSSE } from '@/src/lib/drainSSE'
+import { trackShareEvent } from '@/src/lib/trackShareEvent'
 
 const SUGGEST_RE = /\[SUGGEST:\s*([^\]]+)\]$/
 function parseSuggestions(content) {
@@ -157,6 +158,43 @@ export default function ReportViewer({
   const downloadRef = useRef(null)
   const resendEmailRef = useRef(null)
   const chatPanelRef = useRef(null)
+
+  // Share-link recipient tracking: when a prospect opens "Edit with chat" from
+  // the email, record the open and how long they spend on the page (the chat
+  // panel session). Only runs for share-link visitors; employees/owners are
+  // not tracked. session-end uses sendBeacon (in trackShareEvent) so it fires
+  // even as the tab closes.
+  useEffect(() => {
+    if (!isShareLink || !shareToken || !reportId) return undefined
+
+    const startedAt = Date.now()
+    trackShareEvent({ reportId, shareToken, type: 'chat_link_opened' })
+
+    let sent = false
+    const endSession = () => {
+      if (sent) return
+      sent = true
+      trackShareEvent({
+        reportId,
+        shareToken,
+        type: 'chat_session_end',
+        durationMs: Date.now() - startedAt,
+      })
+    }
+
+    // pagehide is the most reliable unload signal across browsers (incl. mobile
+    // bfcache); visibilitychange→hidden catches tab switches/closes too.
+    const onHide = () => endSession()
+    window.addEventListener('pagehide', onHide)
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'hidden') endSession()
+    })
+
+    return () => {
+      window.removeEventListener('pagehide', onHide)
+      endSession()
+    }
+  }, [isShareLink, shareToken, reportId])
 
   const TOUR_STEPS = [
     {
@@ -471,13 +509,21 @@ export default function ReportViewer({
       document.body.removeChild(a)
       URL.revokeObjectURL(url)
 
+      if (isShareLink && shareToken) {
+        trackShareEvent({
+          reportId,
+          shareToken,
+          type: 'pdf_downloaded_share',
+        })
+      }
+
       setDownloadStatus('idle')
     } catch (err) {
       console.error('[ReportViewer] PDF download failed:', err)
       setDownloadStatus('error')
       setTimeout(() => setDownloadStatus('idle'), 3000)
     }
-  }, [downloadStatus, reportId, activeTab])
+  }, [downloadStatus, reportId, activeTab, isShareLink, shareToken])
 
   const handleResendEmail = useCallback(async () => {
     if (!reportId || emailStatus === 'sending') return

--- a/src/components/ROIGenerator/ReportViewer.jsx
+++ b/src/components/ROIGenerator/ReportViewer.jsx
@@ -185,13 +185,15 @@ export default function ReportViewer({
     // pagehide is the most reliable unload signal across browsers (incl. mobile
     // bfcache); visibilitychange→hidden catches tab switches/closes too.
     const onHide = () => endSession()
-    window.addEventListener('pagehide', onHide)
-    document.addEventListener('visibilitychange', () => {
+    const onVisibility = () => {
       if (document.visibilityState === 'hidden') endSession()
-    })
+    }
+    window.addEventListener('pagehide', onHide)
+    document.addEventListener('visibilitychange', onVisibility)
 
     return () => {
       window.removeEventListener('pagehide', onHide)
+      document.removeEventListener('visibilitychange', onVisibility)
       endSession()
     }
   }, [isShareLink, shareToken, reportId])

--- a/src/lib/roi/agent.ts
+++ b/src/lib/roi/agent.ts
@@ -20,7 +20,6 @@ import { z } from 'zod'
 
 import { researchModel, fastModel } from '@/src/lib/roi/llm'
 import { UsageTracker } from '@/src/lib/roi/services/usageTracker'
-import { persistUsage } from '@/src/lib/roi/services/usageStore'
 import { webSearch } from '@/src/lib/roi/tools/webSearch'
 import { fetchPage } from '@/src/lib/roi/tools/fetchPage'
 import { roiCalculator } from '@/src/lib/roi/pipeline/roiCalculator'
@@ -2032,9 +2031,10 @@ ${
   } catch {
     /* usage not available — skip */
   }
-  // Persist to Supabase for the monitoring dashboard. Fire-and-forget: a
-  // monitoring write must never block the response or fail report generation.
-  void persistUsage(tracker.flush())
+  // Hand the usage summary to the caller, which persists it once the report
+  // row (report_id) exists. In generate mode the report is saved AFTER the
+  // agent runs, so the agent itself has no report_id to write.
+  callbacks.onUsage?.(tracker.flush())
 
   if (mode === 'generate' && !state.assembled) {
     const done =

--- a/src/lib/roi/agent.ts
+++ b/src/lib/roi/agent.ts
@@ -20,6 +20,7 @@ import { z } from 'zod'
 
 import { researchModel, fastModel } from '@/src/lib/roi/llm'
 import { UsageTracker } from '@/src/lib/roi/services/usageTracker'
+import { persistUsage } from '@/src/lib/roi/services/usageStore'
 import { webSearch } from '@/src/lib/roi/tools/webSearch'
 import { fetchPage } from '@/src/lib/roi/tools/fetchPage'
 import { roiCalculator } from '@/src/lib/roi/pipeline/roiCalculator'
@@ -2031,7 +2032,9 @@ ${
   } catch {
     /* usage not available — skip */
   }
-  tracker.flush()
+  // Persist to Supabase for the monitoring dashboard. Fire-and-forget: a
+  // monitoring write must never block the response or fail report generation.
+  void persistUsage(tracker.flush())
 
   if (mode === 'generate' && !state.assembled) {
     const done =

--- a/src/lib/roi/services/usageStore.ts
+++ b/src/lib/roi/services/usageStore.ts
@@ -14,19 +14,33 @@ import { supabaseAdmin } from '@/src/lib/supabaseAdmin'
 
 import type { UsageSummary } from './usageTracker'
 
-export async function persistUsage(summary: UsageSummary): Promise<void> {
+export async function persistUsage(
+  summary: UsageSummary,
+  ids: { reportId: string; userId?: string | null },
+): Promise<void> {
+  // report_id is NOT NULL with a unique(report_id) constraint, so we need a
+  // saved report before we can persist. Skip if it's missing rather than throw.
+  if (!ids?.reportId) {
+    console.warn('[roi-usage] persistUsage skipped — no reportId')
+    return
+  }
   try {
-    const { error } = await supabaseAdmin.from('roi_usage').insert({
-      ts: summary.ts,
-      company: summary.company,
-      mode: summary.mode,
-      duration_ms: summary.durationMs,
-      input_tokens: summary.totals.inputTokens,
-      output_tokens: summary.totals.outputTokens,
-      total_tokens: summary.totals.totalTokens,
-      cost_usd: summary.totals.costUsd,
-      calls: summary.calls,
-    })
+    // created_at defaults to now() in the DB; the table has no `ts` column.
+    const { error } = await supabaseAdmin.from('roi_usage').upsert(
+      {
+        report_id: ids.reportId,
+        user_id: ids.userId ?? null,
+        company: summary.company,
+        mode: summary.mode,
+        duration_ms: summary.durationMs,
+        input_tokens: summary.totals.inputTokens,
+        output_tokens: summary.totals.outputTokens,
+        total_tokens: summary.totals.totalTokens,
+        cost_usd: summary.totals.costUsd,
+        calls: summary.calls,
+      },
+      { onConflict: 'report_id' },
+    )
     if (error) {
       console.warn('[roi-usage] Supabase insert failed:', error.message)
     }

--- a/src/lib/roi/services/usageStore.ts
+++ b/src/lib/roi/services/usageStore.ts
@@ -25,22 +25,22 @@ export async function persistUsage(
     return
   }
   try {
-    // created_at defaults to now() in the DB; the table has no `ts` column.
-    const { error } = await supabaseAdmin.from('roi_usage').upsert(
-      {
-        report_id: ids.reportId,
-        user_id: ids.userId ?? null,
-        company: summary.company,
-        mode: summary.mode,
-        duration_ms: summary.durationMs,
-        input_tokens: summary.totals.inputTokens,
-        output_tokens: summary.totals.outputTokens,
-        total_tokens: summary.totals.totalTokens,
-        cost_usd: summary.totals.costUsd,
-        calls: summary.calls,
-      },
-      { onConflict: 'report_id' },
-    )
+    // Additive upsert: a report's cost accrues across the initial generation
+    // AND every chat turn. The upsert_roi_usage RPC sums cost/tokens/duration
+    // and concatenates calls on conflict, so a cheap chat turn never overwrites
+    // the expensive generation row. created_at defaults to now() in the DB.
+    const { error } = await supabaseAdmin.rpc('upsert_roi_usage', {
+      p_report_id: ids.reportId,
+      p_user_id: ids.userId ?? null,
+      p_company: summary.company,
+      p_mode: summary.mode,
+      p_duration_ms: summary.durationMs,
+      p_input_tokens: summary.totals.inputTokens,
+      p_output_tokens: summary.totals.outputTokens,
+      p_total_tokens: summary.totals.totalTokens,
+      p_cost_usd: summary.totals.costUsd,
+      p_calls: summary.calls,
+    })
     if (error) {
       console.warn('[roi-usage] Supabase insert failed:', error.message)
     }

--- a/src/lib/roi/services/usageStore.ts
+++ b/src/lib/roi/services/usageStore.ts
@@ -1,0 +1,36 @@
+/* eslint-disable no-console */
+// ─────────────────────────────────────────────────────────────────────────────
+// usageStore — persists a UsageSummary to Supabase (roi_usage table).
+//
+// Kept separate from UsageTracker so the tracker stays pure (usable in evals /
+// local scripts with no DB). On Vercel the local NDJSON file written by
+// flush() is ephemeral, so this is the durable sink that feeds the dashboard.
+//
+// Fire-and-forget: never throws into the request path. A monitoring write must
+// never break report generation.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { supabaseAdmin } from '@/src/lib/supabaseAdmin'
+
+import type { UsageSummary } from './usageTracker'
+
+export async function persistUsage(summary: UsageSummary): Promise<void> {
+  try {
+    const { error } = await supabaseAdmin.from('roi_usage').insert({
+      ts: summary.ts,
+      company: summary.company,
+      mode: summary.mode,
+      duration_ms: summary.durationMs,
+      input_tokens: summary.totals.inputTokens,
+      output_tokens: summary.totals.outputTokens,
+      total_tokens: summary.totals.totalTokens,
+      cost_usd: summary.totals.costUsd,
+      calls: summary.calls,
+    })
+    if (error) {
+      console.warn('[roi-usage] Supabase insert failed:', error.message)
+    }
+  } catch (err) {
+    console.warn('[roi-usage] persistUsage threw:', err)
+  }
+}

--- a/src/lib/roi/types.ts
+++ b/src/lib/roi/types.ts
@@ -388,6 +388,9 @@ export interface AgentCallbacks {
   onReportUpdate(state: ReportState, changedSections?: string[]): void
   onDone(newMessages: import('ai').ModelMessage[]): void
   onError(err: Error): void
+  // Fired once with the per-run LLM usage summary. The caller persists it to
+  // roi_usage once a report_id is available (see usageStore.persistUsage).
+  onUsage?(summary: import('./services/usageTracker').UsageSummary): void
 }
 
 // ── SSE event types ──────────────────────────────────────────────────────────

--- a/src/lib/trackShareEvent.js
+++ b/src/lib/trackShareEvent.js
@@ -1,0 +1,39 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// trackShareEvent — client-side helper to log share-link recipient behaviour.
+//
+// Fire-and-forget; never throws into the UI. Posts to /api/track/share-event,
+// which validates the share token before writing to the `events` table.
+//
+// For session-end we prefer navigator.sendBeacon: it survives the page being
+// closed/navigated away, which a normal fetch does not. That's what lets us
+// reliably capture how long the recipient spent in the chat panel.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function trackShareEvent({ reportId, shareToken, type, durationMs }) {
+  if (!reportId || !shareToken || !type) return
+  const payload = JSON.stringify({ reportId, shareToken, type, durationMs })
+
+  try {
+    if (
+      typeof navigator !== 'undefined' &&
+      typeof navigator.sendBeacon === 'function'
+    ) {
+      const blob = new Blob([payload], { type: 'application/json' })
+      navigator.sendBeacon('/api/track/share-event', blob)
+      return
+    }
+  } catch {
+    /* fall through to fetch */
+  }
+
+  try {
+    fetch('/api/track/share-event', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: payload,
+      keepalive: true, // best-effort if the page is unloading
+    }).catch(() => {})
+  } catch {
+    /* tracking must never break the page */
+  }
+}

--- a/supabase/migrations/20260603_000005_roi_usage.sql
+++ b/supabase/migrations/20260603_000005_roi_usage.sql
@@ -1,0 +1,37 @@
+-- Per-report LLM cost / time / token monitoring for the internal dashboard.
+-- One row per generated report (or chat turn). Written via the service-role
+-- key (supabaseAdmin, bypasses RLS); read only by employees.
+
+create table if not exists public.roi_usage (
+  id uuid primary key default gen_random_uuid(),
+  ts timestamptz not null default now(),
+  company text,
+  mode text,                       -- 'generate' | 'chat'
+  duration_ms integer,
+  input_tokens integer,
+  output_tokens integer,
+  total_tokens integer,
+  cost_usd numeric(12, 6),
+  calls jsonb,                     -- per-call breakdown: [{call, model, inputTokens, outputTokens, totalTokens, costUsd}]
+  created_at timestamptz not null default now()
+);
+
+create index if not exists roi_usage_ts_idx
+  on public.roi_usage (ts desc);
+
+create index if not exists roi_usage_mode_ts_idx
+  on public.roi_usage (mode, ts desc);
+
+alter table public.roi_usage enable row level security;
+
+drop policy if exists "roi_usage_select_employee" on public.roi_usage;
+create policy "roi_usage_select_employee"
+  on public.roi_usage
+  for select
+  using (
+    exists (
+      select 1
+      from public.users u
+      where u.id = auth.uid() and u.role = 'EMPLOYEE'
+    )
+  );

--- a/supabase/migrations/20260603_000005_roi_usage.sql
+++ b/supabase/migrations/20260603_000005_roi_usage.sql
@@ -1,26 +1,35 @@
 -- Per-report LLM cost / time / token monitoring for the internal dashboard.
--- One row per generated report (or chat turn). Written via the service-role
--- key (supabaseAdmin, bypasses RLS); read only by employees.
+-- One row per report (upserted on report_id). Written via the service-role key
+-- (supabaseAdmin, bypasses RLS); read only by employees.
+--
+-- NOTE: this mirrors the schema actually applied in Supabase (canonical). Time
+-- column is created_at (not ts); report_id is required and unique.
 
 create table if not exists public.roi_usage (
   id uuid primary key default gen_random_uuid(),
-  ts timestamptz not null default now(),
+  report_id uuid not null references public.reports (id) on delete cascade,
+  user_id uuid references auth.users (id) on delete set null,
   company text,
-  mode text,                       -- 'generate' | 'chat'
-  duration_ms integer,
-  input_tokens integer,
-  output_tokens integer,
-  total_tokens integer,
-  cost_usd numeric(12, 6),
-  calls jsonb,                     -- per-call breakdown: [{call, model, inputTokens, outputTokens, totalTokens, costUsd}]
+  mode text not null default 'generate'
+    check (mode = any (array['generate'::text, 'chat'::text])),
+  duration_ms integer not null default 0,
+  input_tokens integer not null default 0,
+  output_tokens integer not null default 0,
+  total_tokens integer not null default 0,
+  cost_usd numeric(12, 6) not null default 0,
+  calls jsonb not null default '[]'::jsonb,
   created_at timestamptz not null default now()
 );
 
-create index if not exists roi_usage_ts_idx
-  on public.roi_usage (ts desc);
+-- One usage row per report (chat turns upsert onto the same row).
+create unique index if not exists roi_usage_report_key
+  on public.roi_usage (report_id);
 
-create index if not exists roi_usage_mode_ts_idx
-  on public.roi_usage (mode, ts desc);
+create index if not exists roi_usage_user_created_idx
+  on public.roi_usage (user_id, created_at desc);
+
+create index if not exists roi_usage_created_idx
+  on public.roi_usage (created_at desc);
 
 alter table public.roi_usage enable row level security;
 

--- a/supabase/migrations/20260603_000006_events_meta.sql
+++ b/supabase/migrations/20260603_000006_events_meta.sql
@@ -1,0 +1,6 @@
+-- Add a nullable JSONB `meta` column to events for ad-hoc event metadata
+-- (first use: chat session durationMs for share-link recipients). Additive and
+-- safe: existing rows get NULL, existing inserts are unaffected.
+
+alter table public.events
+  add column if not exists meta jsonb;

--- a/supabase/migrations/20260603_000007_roi_usage_accumulate.sql
+++ b/supabase/migrations/20260603_000007_roi_usage_accumulate.sql
@@ -1,0 +1,59 @@
+-- Additive upsert for roi_usage. The table keeps ONE row per report
+-- (unique on report_id), but a report's cost accrues across the initial
+-- generation AND every subsequent chat turn. A plain upsert would REPLACE
+-- the row, so the expensive generation cost would be overwritten by a cheap
+-- chat turn and the dashboard would undercount real spend.
+--
+-- This function merges instead: on conflict it sums cost/tokens/duration and
+-- concatenates the per-call breakdown. `company` is kept from the first write
+-- (generation), and `mode` reflects the latest activity. user_id is filled in
+-- if it was previously null.
+
+create or replace function public.upsert_roi_usage(
+  p_report_id uuid,
+  p_user_id uuid,
+  p_company text,
+  p_mode text,
+  p_duration_ms int,
+  p_input_tokens int,
+  p_output_tokens int,
+  p_total_tokens int,
+  p_cost_usd numeric,
+  p_calls jsonb
+) returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into public.roi_usage (
+    report_id, user_id, company, mode,
+    duration_ms, input_tokens, output_tokens, total_tokens, cost_usd, calls
+  ) values (
+    p_report_id, p_user_id, p_company, p_mode,
+    coalesce(p_duration_ms, 0),
+    coalesce(p_input_tokens, 0),
+    coalesce(p_output_tokens, 0),
+    coalesce(p_total_tokens, 0),
+    coalesce(p_cost_usd, 0),
+    coalesce(p_calls, '[]'::jsonb)
+  )
+  on conflict (report_id) do update set
+    duration_ms   = roi_usage.duration_ms   + coalesce(excluded.duration_ms, 0),
+    input_tokens  = roi_usage.input_tokens  + coalesce(excluded.input_tokens, 0),
+    output_tokens = roi_usage.output_tokens + coalesce(excluded.output_tokens, 0),
+    total_tokens  = roi_usage.total_tokens  + coalesce(excluded.total_tokens, 0),
+    cost_usd      = roi_usage.cost_usd      + coalesce(excluded.cost_usd, 0),
+    calls         = roi_usage.calls || coalesce(excluded.calls, '[]'::jsonb),
+    -- keep the original company; surface the most recent mode/user.
+    mode          = excluded.mode,
+    user_id       = coalesce(roi_usage.user_id, excluded.user_id);
+end;
+$$;
+
+revoke all on function public.upsert_roi_usage(
+  uuid, uuid, text, text, int, int, int, int, numeric, jsonb
+) from public;
+grant execute on function public.upsert_roi_usage(
+  uuid, uuid, text, text, int, int, int, int, numeric, jsonb
+) to service_role;


### PR DESCRIPTION
This branch adds a roi_usage table migration (supabase/migrations/20260603_000005_roi_usage.sql) for the monitoring dashboard. The migration needs to be applied to the database — the agent code already writes rows via persistUsage(), but they'll no-op (logging a warning) until the table exists. No app behavior changes otherwise; the write is fire-and-forget and can't break report generation.