### PR TITLE
Feat/error handling and kpi

### DIFF
--- a/pages/api/notify-error.js
+++ b/pages/api/notify-error.js
@@ -1,0 +1,28 @@
+import { notifyDevTeam } from '@/src/lib/notifyError'
+import { createClient } from '../../src/lib/supabase-server'
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const { error, stack, context, url } = req.body ?? {}
+  if (!error || typeof error !== 'string') {
+    return res.status(400).json({ error: 'Missing error' })
+  }
+
+  let userEmail
+  try {
+    const supabase = createClient(req, res)
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+    userEmail = user?.email
+  } catch {
+    // non-authenticated users (e.g. share-link visitors) — that's fine
+  }
+
+  await notifyDevTeam({ error, stack, context, userEmail, url })
+
+  res.status(200).json({ ok: true })
+}

--- a/pages/api/notify-error.js
+++ b/pages/api/notify-error.js
@@ -1,9 +1,64 @@
 import { notifyDevTeam } from '@/src/lib/notifyError'
 import { createClient } from '../../src/lib/supabase-server'
 
+// This endpoint is intentionally unauthenticated (share-link visitors hit it),
+// so it trusts arbitrary input. Two guards keep it from being abused as an
+// email-spam amplifier:
+//   1. per-IP throttle (in-memory; best-effort across a single instance)
+//   2. hard size caps on every field before it reaches the email
+const RATE_LIMIT_WINDOW_MS = 60_000
+const RATE_LIMIT_MAX = 5 // alerts per IP per window
+const MAX_FIELD_LEN = 4_000
+const MAX_STACK_LEN = 20_000
+const MAX_CONTEXT_KEYS = 20
+
+// ip -> array of request timestamps within the current window
+const hits = new Map()
+
+function isRateLimited(ip) {
+  const now = Date.now()
+  const recent = (hits.get(ip) ?? []).filter(
+    (t) => now - t < RATE_LIMIT_WINDOW_MS,
+  )
+  if (recent.length >= RATE_LIMIT_MAX) {
+    hits.set(ip, recent)
+    return true
+  }
+  recent.push(now)
+  hits.set(ip, recent)
+  return false
+}
+
+function clampStr(value, max) {
+  return typeof value === 'string' ? value.slice(0, max) : undefined
+}
+
+function sanitizeContext(context) {
+  if (!context || typeof context !== 'object' || Array.isArray(context)) {
+    return undefined
+  }
+  const out = Object.fromEntries(
+    Object.entries(context)
+      .slice(0, MAX_CONTEXT_KEYS)
+      .map(([k, v]) => [
+        String(k).slice(0, 200),
+        String(v ?? '').slice(0, MAX_FIELD_LEN),
+      ]),
+  )
+  return Object.keys(out).length ? out : undefined
+}
+
 export default async function handler(req, res) {
   if (req.method !== 'POST') {
     return res.status(405).json({ error: 'Method not allowed' })
+  }
+
+  const ip =
+    (req.headers['x-forwarded-for'] ?? '').split(',')[0].trim() ||
+    req.socket?.remoteAddress ||
+    'unknown'
+  if (isRateLimited(ip)) {
+    return res.status(429).json({ error: 'Too many requests' })
   }
 
   const { error, stack, context, url } = req.body ?? {}
@@ -22,7 +77,13 @@ export default async function handler(req, res) {
     // non-authenticated users (e.g. share-link visitors) — that's fine
   }
 
-  await notifyDevTeam({ error, stack, context, userEmail, url })
+  await notifyDevTeam({
+    error: clampStr(error, MAX_FIELD_LEN),
+    stack: clampStr(stack, MAX_STACK_LEN),
+    context: sanitizeContext(context),
+    userEmail,
+    url: clampStr(url, MAX_FIELD_LEN),
+  })
 
-  res.status(200).json({ ok: true })
+  return res.status(200).json({ ok: true })
 }

--- a/pages/dashboard.jsx
+++ b/pages/dashboard.jsx
@@ -10,6 +10,7 @@ import {
 import { createClient as createBrowserClient } from '../src/lib/supabase-browser'
 import MainHeader from '../src/layout/MainHeader/index'
 import { getRoleForUser } from '../src/lib/authHelpers'
+import ErrorBoundary from '../src/components/shared/ErrorBoundary'
 
 const STATUS_STYLES = {
   SUCCESS: { bg: 'bg-green-50', text: 'text-green-700', label: 'Done' },
@@ -143,6 +144,11 @@ export async function getServerSideProps({ req, res }) {
     (r) => r.created_at >= oneWeekAgoIso,
   ).length
 
+  const todayStartIso = new Date(new Date().setUTCHours(0, 0, 0, 0)).toISOString()
+  const reportsToday = (reports ?? []).filter(
+    (r) => r.created_at >= todayStartIso,
+  ).length
+
   if (!isEmployee) {
     return {
       props: {
@@ -153,6 +159,7 @@ export async function getServerSideProps({ req, res }) {
         isEmployee,
         reports: withRequester(reports, () => user.email),
         reportsThisWeek,
+        reportsToday,
         users: [],
         recentEvents: [],
       },
@@ -206,18 +213,20 @@ export async function getServerSideProps({ req, res }) {
       userId: user.id,
       reports: withRequester(reports, (r) => userEmailById[r.user_id]),
       reportsThisWeek,
+      reportsToday,
       users: usersWithStats,
       recentEvents,
     },
   }
 }
 
-export default function Dashboard({
+function DashboardInner({
   user,
   reports: initialReports,
   isEmployee,
   userId,
   reportsThisWeek,
+  reportsToday,
   users,
   recentEvents,
 }) {
@@ -299,10 +308,11 @@ export default function Dashboard({
         {/* Employee: stats + tabs */}
         {isEmployee && (
           <>
-            <div className="grid grid-cols-3 gap-4 mb-6">
+            <div className="grid grid-cols-4 gap-4 mb-6">
               <StatCard label="Total Users" value={users.length} />
               <StatCard label="Total Reports" value={reports.length} />
               <StatCard label="Reports This Week" value={reportsThisWeek} />
+              <StatCard label="Reports Today" value={reportsToday} />
             </div>
 
             <div className="flex gap-1 p-1 mb-6 bg-gray-100 rounded-xl w-fit">
@@ -568,5 +578,16 @@ export default function Dashboard({
         )}
       </div>
     </div>
+  )
+}
+
+export default function Dashboard(props) {
+  return (
+    <ErrorBoundary
+      isEmployee={props.isEmployee}
+      pageContext={{ page: 'dashboard' }}
+    >
+      <DashboardInner {...props} />
+    </ErrorBoundary>
   )
 }

--- a/pages/report/[id].jsx
+++ b/pages/report/[id].jsx
@@ -3,6 +3,7 @@ import { createClient, createAdminClient } from '../../src/lib/supabase-server'
 import ReportViewerWithBatch from '../../src/components/ROIGenerator/BulkUpload/ReportViewerWithBatch'
 import { buildStateFromReportRow } from '@/src/lib/roi/reportState'
 import { motion } from 'framer-motion'
+import ErrorBoundary from '../../src/components/shared/ErrorBoundary'
 
 export async function getServerSideProps({ req, res, params, query }) {
   const supabase = createClient(req, res)
@@ -127,7 +128,10 @@ export default function ReportPage({
   shareToken,
 }) {
   return (
-    <>
+    <ErrorBoundary
+      isEmployee={isEmployee}
+      pageContext={{ page: 'report', reportId }}
+    >
       <Head>
         <title>ROI Report | LyRise</title>
       </Head>
@@ -149,6 +153,6 @@ export default function ReportPage({
           backHref={isShareLink ? null : '/dashboard'}
         />
       </motion.div>
-    </>
+    </ErrorBoundary>
   )
 }

--- a/pages/roi-report.jsx
+++ b/pages/roi-report.jsx
@@ -12,6 +12,7 @@ import GeneratingView from '../src/components/ROIGenerator/GeneratingView'
 import { drainSSE } from '../src/lib/drainSSE'
 import { PIPELINE_LOG_TOOL_NAMES } from '../src/lib/roi/constants'
 import { useRouter } from 'next/router'
+import ErrorBoundary from '../src/components/shared/ErrorBoundary'
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -367,12 +368,18 @@ function Step2({ data, onChange, errors, isDev }) {
 
 // ── Generating & Success views ────────────────────────────────────────────────
 
-function ErrorView({ message, onRetry, onUseEstimates }) {
+function ErrorView({ message, onRetry, onUseEstimates, isEmployee }) {
   const isResearchFailure =
     message?.includes('Stages done: none') ||
     message?.includes('no assembled report') ||
     message?.includes("couldn't research") ||
     message?.includes('retrieve specific web pages')
+
+  const displayMessage =
+    isEmployee || isResearchFailure
+      ? message
+      : 'Something went wrong. Our team has been notified and will look into it.'
+
   return (
     <div className="px-8 py-10 text-center">
       <div
@@ -413,7 +420,7 @@ function ErrorView({ message, onRetry, onUseEstimates }) {
       ) : (
         <>
           <p className="max-w-sm mx-auto mb-6 text-sm text-gray-500">
-            {message || 'Something went wrong. Please try again.'}
+            {displayMessage || 'Something went wrong. Please try again.'}
           </p>
           <div className="flex flex-col max-w-xs gap-3 mx-auto">
             <button
@@ -693,7 +700,7 @@ function sseEventToLogLine(event) {
   return labels[event.tool] ?? `[${event.tool}]`
 }
 
-export default function ROIReport({ isEmployee }) {
+function ROIReportInner({ isEmployee }) {
   const router = useRouter()
   const [step, setStep] = useState(1)
   const [viewState, setViewState] = useState(VIEW_STATES.FORM)
@@ -726,6 +733,25 @@ export default function ROIReport({ isEmployee }) {
       : { email: '', recipientName: '', recipientTitle: '', currency: '' },
   )
   const [errors, setErrors] = useState({})
+
+  const handleGenerationError = useCallback(
+    (message) => {
+      setErrorMessage(message)
+      setViewState(VIEW_STATES.ERROR)
+      if (!isEmployee) {
+        fetch('/api/notify-error', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            error: message,
+            context: { page: 'roi-report', company: s1.companyName || '(unknown)' },
+            url: typeof window !== 'undefined' ? window.location.href : undefined,
+          }),
+        }).catch(() => {})
+      }
+    },
+    [isEmployee, s1.companyName],
+  )
 
   const changeS1 = useCallback((key, val) => {
     setS1((prev) => ({ ...prev, [key]: val }))
@@ -850,10 +876,9 @@ export default function ROIReport({ isEmployee }) {
                 setIsGenerationComplete(true)
                 setViewState(VIEW_STATES.FINALISING)
               } else {
-                setErrorMessage(
+                handleGenerationError(
                   'Report generation finished without a complete report.',
                 )
-                setViewState(VIEW_STATES.ERROR)
               }
             } else if (event.type === 'error') {
               throw new Error(event.message)
@@ -861,13 +886,12 @@ export default function ROIReport({ isEmployee }) {
           },
         )
       } catch (err) {
-        setErrorMessage(
+        handleGenerationError(
           err.message || 'Something went wrong. Please try again.',
         )
-        setViewState(VIEW_STATES.ERROR)
       }
     },
-    [s1, s2],
+    [s1, s2, handleGenerationError],
   )
 
   // Finalisation lifecycle: enforce minimum visible loader duration, then
@@ -906,13 +930,12 @@ export default function ROIReport({ isEmployee }) {
       return () => clearTimeout(timeout)
     }
     const fallback = setTimeout(() => {
-      setErrorMessage(
+      handleGenerationError(
         'Report was generated but could not be saved. Please try again or check server logs.',
       )
-      setViewState(VIEW_STATES.ERROR)
     }, 8000)
     return () => clearTimeout(fallback)
-  }, [viewState, reportId, router])
+  }, [viewState, reportId, router, handleGenerationError])
 
   const next = useCallback(
     async ({ skipLLM = false } = {}) => {
@@ -1001,6 +1024,7 @@ export default function ROIReport({ isEmployee }) {
               message={errorMessage}
               onRetry={() => runGeneration()}
               onUseEstimates={() => runGeneration({ estimatesOnly: true })}
+              isEmployee={isEmployee}
             />
           </div>
         </div>
@@ -1128,5 +1152,16 @@ export default function ROIReport({ isEmployee }) {
       </div>
       <LastSection />
     </div>
+  )
+}
+
+export default function ROIReport(props) {
+  return (
+    <ErrorBoundary
+      isEmployee={props.isEmployee}
+      pageContext={{ page: 'roi-report' }}
+    >
+      <ROIReportInner {...props} />
+    </ErrorBoundary>
   )
 }

--- a/src/components/shared/ErrorBoundary.jsx
+++ b/src/components/shared/ErrorBoundary.jsx
@@ -1,0 +1,204 @@
+import React from 'react'
+
+function parseComponentStack(stack) {
+  if (!stack) return []
+  return stack
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line && !line.includes('node_modules'))
+    .map((line) => {
+      const match = line.match(
+        /at (\w+) \(webpack-internal:\/\/\/\.\/(.+?):(\d+):\d+\)/,
+      )
+      if (match) return { name: match[1], file: match[2], line: match[3] }
+      const fallback = line.match(/at (\w+)/)
+      if (fallback) return { name: fallback[1], file: null, line: null }
+      return null
+    })
+    .filter(Boolean)
+}
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      hasError: false,
+      error: null,
+      componentStack: null,
+      errorTime: null,
+      url: null,
+    }
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error, errorTime: new Date().toISOString() }
+  }
+
+  componentDidCatch(error, info) {
+    this.setState({
+      componentStack: info.componentStack,
+      url: typeof window !== 'undefined' ? window.location.href : null,
+    })
+    const { isEmployee, pageContext } = this.props
+    if (!isEmployee) {
+      fetch('/api/notify-error', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          error: error.message,
+          stack: info.componentStack,
+          context: pageContext,
+          url: typeof window !== 'undefined' ? window.location.href : undefined,
+        }),
+      }).catch(() => {})
+    }
+  }
+
+  render() {
+    const { hasError, error, componentStack, errorTime, url } = this.state
+    const { isEmployee, children, pageContext } = this.props
+
+    if (!hasError) return children
+
+    if (isEmployee) {
+      const parsed = parseComponentStack(componentStack)
+      const origin = parsed[0]
+      const chain = parsed.map((c) => c.name).join(' → ')
+
+      const contextLines = pageContext
+        ? Object.entries(pageContext).map(([k, v]) => `${k}: ${v}`)
+        : []
+
+      const copyText = [
+        `Error: ${error?.message}`,
+        `Time: ${errorTime}`,
+        url ? `URL: ${url}` : '',
+        origin
+          ? `Location: ${origin.file}:${origin.line} in ${origin.name}`
+          : '',
+        ...contextLines,
+        '',
+        'Component chain:',
+        chain,
+        '',
+        'Full component stack:',
+        componentStack ?? '',
+      ]
+        .filter((l) => l !== undefined)
+        .join('\n')
+
+      return (
+        <div className="max-w-2xl mx-auto px-6 py-12">
+          <div className="bg-red-50 border border-red-200 rounded-2xl overflow-hidden">
+            {/* Header */}
+            <div className="flex items-start justify-between px-6 pt-6 pb-4 border-b border-red-100">
+              <div>
+                <div className="flex items-center gap-2 mb-1">
+                  <span className="w-2.5 h-2.5 rounded-full bg-red-500 flex-shrink-0" />
+                  <h2 className="font-outfit text-base font-bold text-red-700">
+                    Render Error
+                  </h2>
+                </div>
+                <p className="font-mono text-sm text-red-600 ml-[18px] break-all">
+                  {error?.message}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() =>
+                  navigator.clipboard.writeText(copyText).catch(() => {})
+                }
+                className="ml-4 flex-shrink-0 font-outfit text-xs font-semibold text-gray-500 bg-white border border-gray-200 rounded-lg px-3 py-1.5 hover:border-gray-400 transition-colors"
+              >
+                Copy
+              </button>
+            </div>
+
+            {/* Where */}
+            {origin && (
+              <div className="px-6 py-4 border-b border-red-100">
+                <p className="font-outfit text-[10px] font-semibold text-gray-400 uppercase tracking-wider mb-2">
+                  Where
+                </p>
+                <div className="flex items-center gap-3 flex-wrap">
+                  <span className="font-mono text-sm font-semibold text-gray-800">
+                    {origin.name}
+                  </span>
+                  <span className="text-gray-300">·</span>
+                  <span className="font-mono text-xs text-gray-500">
+                    {origin.file}
+                    {origin.line ? `:${origin.line}` : ''}
+                  </span>
+                </div>
+              </div>
+            )}
+
+            {/* URL */}
+            {url && (
+              <div className="px-6 py-4 border-b border-red-100">
+                <p className="font-outfit text-[10px] font-semibold text-gray-400 uppercase tracking-wider mb-2">
+                  URL
+                </p>
+                <p className="font-mono text-xs text-gray-600 break-all">{url}</p>
+              </div>
+            )}
+
+            {/* Page context */}
+            {pageContext && Object.keys(pageContext).length > 0 && (
+              <div className="px-6 py-4 border-b border-red-100">
+                <p className="font-outfit text-[10px] font-semibold text-gray-400 uppercase tracking-wider mb-2">
+                  Context
+                </p>
+                <div className="flex flex-col gap-1">
+                  {Object.entries(pageContext).map(([k, v]) => (
+                    <div key={k} className="flex items-center gap-2">
+                      <span className="font-outfit text-xs text-gray-400 w-20 flex-shrink-0">{k}</span>
+                      <span className="font-mono text-xs text-gray-600">{v}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* Component chain */}
+            {chain && (
+              <div className="px-6 py-4 border-b border-red-100">
+                <p className="font-outfit text-[10px] font-semibold text-gray-400 uppercase tracking-wider mb-2">
+                  Component chain
+                </p>
+                <p className="font-mono text-xs text-gray-600 leading-relaxed break-all">
+                  {chain}
+                </p>
+              </div>
+            )}
+
+            {/* Timestamp */}
+            <div className="px-6 py-3 bg-red-100/40">
+              <p className="font-outfit text-xs text-gray-400">{errorTime}</p>
+            </div>
+          </div>
+        </div>
+      )
+    }
+
+    return (
+      <div className="max-w-md mx-auto px-6 py-24 text-center">
+        <div
+          className="flex items-center justify-center w-14 h-14 mx-auto mb-5 rounded-full"
+          style={{ background: '#fff7ed', border: '1px solid #fed7aa' }}
+        >
+          <span style={{ fontSize: 24 }}>⚠</span>
+        </div>
+        <h2 className="font-outfit text-xl font-bold text-gray-900 mb-2">
+          Something went wrong
+        </h2>
+        <p className="font-outfit text-sm text-gray-500 leading-relaxed">
+          We&apos;re sorry — something unexpected happened. Our team has been
+          notified and will look into it shortly.
+        </p>
+      </div>
+    )
+  }
+}
+
+export default ErrorBoundary

--- a/src/lib/notifyError.ts
+++ b/src/lib/notifyError.ts
@@ -1,4 +1,29 @@
-const DEV_TEAM = ['mayar@lyrise.ai', 'amira@lyrise.ai']
+const DEFAULT_DEV_TEAM = [
+  'mayar@lyrise.ai',
+  'amira@lyrise.ai',
+  'mbanoub@lyrise.ai',
+  'elena@lyrise.ai',
+  'adel@lyrise.ai',
+  'yousef@lyrise.ai',
+  'omar@lyrise.ai',
+  'y.ashraf@lyrise.ai',
+]
+
+const DEV_TEAM = (process.env.DEV_ALERT_EMAILS ?? DEFAULT_DEV_TEAM.join(','))
+  .split(',')
+  .map((e) => e.trim())
+  .filter(Boolean)
+
+// Escape text interpolated into HTML element content. All values below come from
+// the (unauthenticated) /api/notify-error request body, so they are untrusted.
+function escapeHtml(value: unknown): string {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
 
 interface ParsedFrame {
   name: string
@@ -38,6 +63,15 @@ export async function notifyDevTeam(opts: {
   const frames = stack ? parseAppFrames(stack) : []
   const origin = frames[0]
   const chain = frames.map((f) => f.name).join(' → ')
+
+  // Precomputed to avoid nested template literals in the markup below.
+  const originLineSuffix = origin?.line ? `:${escapeHtml(origin.line)}` : ''
+  const originLocationHtml = origin?.file
+    ? `<span style="color:#6b7280;font-size:13px;margin-left:10px">${escapeHtml(
+        origin.file,
+      )}${originLineSuffix}</span>`
+    : ''
+  const subjectPrefix = origin ? `${origin.name} — ` : ''
   const filteredStack = stack
     ? stack
         .split('\n')
@@ -54,21 +88,27 @@ export async function notifyDevTeam(opts: {
     userEmail
       ? `<tr style="background:#f9fafb">
           <td style="padding:6px 12px;color:#6b7280;font-size:13px;white-space:nowrap">User</td>
-          <td style="padding:6px 12px;font-size:13px">${userEmail}</td>
+          <td style="padding:6px 12px;font-size:13px">${escapeHtml(
+            userEmail,
+          )}</td>
         </tr>`
       : '',
     url
       ? `<tr>
           <td style="padding:6px 12px;color:#6b7280;font-size:13px;white-space:nowrap">URL</td>
-          <td style="padding:6px 12px;font-size:13px"><a href="${url}" style="color:#2957FF">${url}</a></td>
+          <td style="padding:6px 12px;font-size:13px"><a href="${escapeHtml(
+            url,
+          )}" style="color:#2957FF">${escapeHtml(url)}</a></td>
         </tr>`
       : '',
     ...(context
       ? Object.entries(context).map(
           ([k, v], i) =>
             `<tr${i % 2 === 0 ? ' style="background:#f9fafb"' : ''}>
-              <td style="padding:6px 12px;color:#6b7280;font-size:13px;white-space:nowrap">${k}</td>
-              <td style="padding:6px 12px;font-size:13px">${v}</td>
+              <td style="padding:6px 12px;color:#6b7280;font-size:13px;white-space:nowrap">${escapeHtml(
+                k,
+              )}</td>
+              <td style="padding:6px 12px;font-size:13px">${escapeHtml(v)}</td>
             </tr>`,
         )
       : []),
@@ -91,8 +131,10 @@ export async function notifyDevTeam(opts: {
           ? `<div style="background:#fef2f2;border:1px solid #fecaca;border-top:none;padding:14px 24px;display:flex;align-items:center;gap:12px">
               <span style="font-size:18px">📍</span>
               <div>
-                <span style="font-family:monospace;font-size:15px;font-weight:700;color:#991b1b">${origin.name}</span>
-                ${origin.file ? `<span style="color:#6b7280;font-size:13px;margin-left:10px">${origin.file}${origin.line ? `:${origin.line}` : ''}</span>` : ''}
+                <span style="font-family:monospace;font-size:15px;font-weight:700;color:#991b1b">${escapeHtml(
+                  origin.name,
+                )}</span>
+                ${originLocationHtml}
               </div>
             </div>`
           : ''
@@ -102,7 +144,9 @@ export async function notifyDevTeam(opts: {
       <div style="padding:20px 24px;border:1px solid #e5e7eb;border-top:none">
         <p style="margin:0 0 6px;font-size:11px;font-weight:600;color:#6b7280;letter-spacing:.08em;text-transform:uppercase">Error message</p>
         <div style="background:#fef2f2;border:1px solid #fecaca;border-radius:6px;padding:12px 14px">
-          <code style="font-family:monospace;font-size:13px;color:#b91c1c;word-break:break-all">${error}</code>
+          <code style="font-family:monospace;font-size:13px;color:#b91c1c;word-break:break-all">${escapeHtml(
+            error,
+          )}</code>
         </div>
       </div>
 
@@ -119,7 +163,9 @@ export async function notifyDevTeam(opts: {
         chain
           ? `<div style="padding:0 24px 20px;border:1px solid #e5e7eb;border-top:none">
               <p style="margin:0 0 8px;font-size:11px;font-weight:600;color:#6b7280;letter-spacing:.08em;text-transform:uppercase">Component chain</p>
-              <p style="margin:0;font-family:monospace;font-size:12px;color:#374151;word-break:break-all">${chain}</p>
+              <p style="margin:0;font-family:monospace;font-size:12px;color:#374151;word-break:break-all">${escapeHtml(
+                chain,
+              )}</p>
             </div>`
           : ''
       }
@@ -129,7 +175,9 @@ export async function notifyDevTeam(opts: {
         filteredStack
           ? `<div style="padding:0 24px 24px;border:1px solid #e5e7eb;border-top:none;border-radius:0 0 8px 8px">
               <p style="margin:0 0 8px;font-size:11px;font-weight:600;color:#6b7280;letter-spacing:.08em;text-transform:uppercase">Stack trace (app code only)</p>
-              <pre style="margin:0;background:#f9fafb;border:1px solid #e5e7eb;border-radius:6px;padding:12px 14px;font-size:11px;color:#6b7280;white-space:pre-wrap;word-break:break-all;overflow:auto">${filteredStack}</pre>
+              <pre style="margin:0;background:#f9fafb;border:1px solid #e5e7eb;border-radius:6px;padding:12px 14px;font-size:11px;color:#6b7280;white-space:pre-wrap;word-break:break-all;overflow:auto">${escapeHtml(
+                filteredStack,
+              )}</pre>
             </div>`
           : ''
       }
@@ -137,18 +185,34 @@ export async function notifyDevTeam(opts: {
     </div>
   `.trim()
 
-  await fetch('https://api.resend.com/emails', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${apiKey}`,
-    },
-    body: JSON.stringify({
-      from: `LyRise Platform <${process.env.EMAIL_FROM ?? 'reports@roi.lyrise.ai'}>`,
-      to: DEV_TEAM,
-      subject: `[Platform Error] ${origin ? `${origin.name} — ` : ''}${error.slice(0, 60)}`,
-      html,
-    }),
-    signal: AbortSignal.timeout(10_000),
-  }).catch(() => {})
+  // Fire-and-forget: a failed alert must never throw into the request that
+  // triggered it. But don't fail silently either — log so a broken alert
+  // pipeline (bad key, quota, invalid `from`) is visible in server logs.
+  try {
+    const res = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        from: `LyRise Platform <${
+          process.env.EMAIL_FROM ?? 'reports@roi.lyrise.ai'
+        }>`,
+        to: DEV_TEAM,
+        subject: `[Platform Error] ${subjectPrefix}${error.slice(0, 60)}`,
+        html,
+      }),
+      signal: AbortSignal.timeout(10_000),
+    })
+
+    if (!res.ok) {
+      const body = await res.text().catch(() => '')
+      console.error(
+        `[notifyDevTeam] Resend HTTP ${res.status}: ${body.slice(0, 200)}`,
+      )
+    }
+  } catch (err) {
+    console.error('[notifyDevTeam] failed to send error alert:', err)
+  }
 }

--- a/src/lib/notifyError.ts
+++ b/src/lib/notifyError.ts
@@ -1,0 +1,154 @@
+const DEV_TEAM = ['mayar@lyrise.ai', 'amira@lyrise.ai']
+
+interface ParsedFrame {
+  name: string
+  file: string | null
+  line: string | null
+}
+
+function parseAppFrames(stack: string): ParsedFrame[] {
+  return stack
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l && !l.includes('node_modules'))
+    .map((line) => {
+      const match = line.match(
+        /at (\w+) \(webpack-internal:\/\/\/\.\/(.+?):(\d+):\d+\)/,
+      )
+      if (match) return { name: match[1], file: match[2], line: match[3] }
+      const fallback = line.match(/at (\w+)/)
+      if (fallback) return { name: fallback[1], file: null, line: null }
+      return null
+    })
+    .filter((f): f is ParsedFrame => f !== null)
+}
+
+export async function notifyDevTeam(opts: {
+  error: string
+  stack?: string
+  context?: Record<string, string>
+  userEmail?: string
+  url?: string
+}): Promise<void> {
+  const apiKey = process.env.RESEND_API_KEY
+  if (!apiKey) return
+
+  const { error, stack, context, userEmail, url } = opts
+
+  const frames = stack ? parseAppFrames(stack) : []
+  const origin = frames[0]
+  const chain = frames.map((f) => f.name).join(' → ')
+  const filteredStack = stack
+    ? stack
+        .split('\n')
+        .filter((l) => l && !l.includes('node_modules'))
+        .join('\n')
+        .trim()
+    : null
+
+  const metaRows = [
+    `<tr>
+      <td style="padding:6px 12px;color:#6b7280;font-size:13px;white-space:nowrap;width:80px">Time</td>
+      <td style="padding:6px 12px;font-size:13px">${new Date().toISOString()}</td>
+    </tr>`,
+    userEmail
+      ? `<tr style="background:#f9fafb">
+          <td style="padding:6px 12px;color:#6b7280;font-size:13px;white-space:nowrap">User</td>
+          <td style="padding:6px 12px;font-size:13px">${userEmail}</td>
+        </tr>`
+      : '',
+    url
+      ? `<tr>
+          <td style="padding:6px 12px;color:#6b7280;font-size:13px;white-space:nowrap">URL</td>
+          <td style="padding:6px 12px;font-size:13px"><a href="${url}" style="color:#2957FF">${url}</a></td>
+        </tr>`
+      : '',
+    ...(context
+      ? Object.entries(context).map(
+          ([k, v], i) =>
+            `<tr${i % 2 === 0 ? ' style="background:#f9fafb"' : ''}>
+              <td style="padding:6px 12px;color:#6b7280;font-size:13px;white-space:nowrap">${k}</td>
+              <td style="padding:6px 12px;font-size:13px">${v}</td>
+            </tr>`,
+        )
+      : []),
+  ]
+    .filter(Boolean)
+    .join('')
+
+  const html = `
+    <div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;max-width:680px;margin:0 auto">
+
+      <!-- Header -->
+      <div style="background:#dc2626;border-radius:8px 8px 0 0;padding:20px 24px">
+        <p style="margin:0;color:#fca5a5;font-size:11px;font-weight:600;letter-spacing:.08em;text-transform:uppercase">LyRise Platform</p>
+        <h1 style="margin:4px 0 0;color:#fff;font-size:20px;font-weight:700">Error Alert</h1>
+      </div>
+
+      <!-- Origin banner -->
+      ${
+        origin
+          ? `<div style="background:#fef2f2;border:1px solid #fecaca;border-top:none;padding:14px 24px;display:flex;align-items:center;gap:12px">
+              <span style="font-size:18px">📍</span>
+              <div>
+                <span style="font-family:monospace;font-size:15px;font-weight:700;color:#991b1b">${origin.name}</span>
+                ${origin.file ? `<span style="color:#6b7280;font-size:13px;margin-left:10px">${origin.file}${origin.line ? `:${origin.line}` : ''}</span>` : ''}
+              </div>
+            </div>`
+          : ''
+      }
+
+      <!-- Error message -->
+      <div style="padding:20px 24px;border:1px solid #e5e7eb;border-top:none">
+        <p style="margin:0 0 6px;font-size:11px;font-weight:600;color:#6b7280;letter-spacing:.08em;text-transform:uppercase">Error message</p>
+        <div style="background:#fef2f2;border:1px solid #fecaca;border-radius:6px;padding:12px 14px">
+          <code style="font-family:monospace;font-size:13px;color:#b91c1c;word-break:break-all">${error}</code>
+        </div>
+      </div>
+
+      <!-- Meta table -->
+      <div style="border:1px solid #e5e7eb;border-top:none;padding:20px 24px">
+        <p style="margin:0 0 8px;font-size:11px;font-weight:600;color:#6b7280;letter-spacing:.08em;text-transform:uppercase">Details</p>
+        <table style="border-collapse:collapse;width:100%;border:1px solid #e5e7eb;border-radius:6px;overflow:hidden">
+          ${metaRows}
+        </table>
+      </div>
+
+      <!-- Component chain -->
+      ${
+        chain
+          ? `<div style="padding:0 24px 20px;border:1px solid #e5e7eb;border-top:none">
+              <p style="margin:0 0 8px;font-size:11px;font-weight:600;color:#6b7280;letter-spacing:.08em;text-transform:uppercase">Component chain</p>
+              <p style="margin:0;font-family:monospace;font-size:12px;color:#374151;word-break:break-all">${chain}</p>
+            </div>`
+          : ''
+      }
+
+      <!-- Stack trace -->
+      ${
+        filteredStack
+          ? `<div style="padding:0 24px 24px;border:1px solid #e5e7eb;border-top:none;border-radius:0 0 8px 8px">
+              <p style="margin:0 0 8px;font-size:11px;font-weight:600;color:#6b7280;letter-spacing:.08em;text-transform:uppercase">Stack trace (app code only)</p>
+              <pre style="margin:0;background:#f9fafb;border:1px solid #e5e7eb;border-radius:6px;padding:12px 14px;font-size:11px;color:#6b7280;white-space:pre-wrap;word-break:break-all;overflow:auto">${filteredStack}</pre>
+            </div>`
+          : ''
+      }
+
+    </div>
+  `.trim()
+
+  await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      from: `LyRise Platform <${process.env.EMAIL_FROM ?? 'reports@roi.lyrise.ai'}>`,
+      to: DEV_TEAM,
+      subject: `[Platform Error] ${origin ? `${origin.name} — ` : ''}${error.slice(0, 60)}`,
+      html,
+    }),
+    signal: AbortSignal.timeout(10_000),
+  }).catch(() => {})
+}


### PR DESCRIPTION
## Summary

- **Role-based error handling** — employees see a detailed error card (component name, file:line, component chain, timestamp, copy button); clients see a friendly apology with no technical details
- **Automated dev alerts** — when a client hits an error, a structured email is sent to `mayar@lyrise.ai` and `amira@lyrise.ai` with the error message, exact location, component chain, and app-only stack trace
- **Reports Today KPI** — new 4th stat card on the admin dashboard (UTC day boundary)

## Files changed

| File | What |
|---|---|
| `src/lib/notifyError.ts` | Resend email utility for dev alerts |
| `pages/api/notify-error.js` | API endpoint that receives client-side errors and fires the alert |
| `src/components/shared/ErrorBoundary.jsx` | React error boundary with role-aware display |
| `pages/dashboard.jsx` | Wrapped with ErrorBoundary + Reports Today KPI |
| `pages/roi-report.jsx` | Wrapped with ErrorBoundary + unified error handler |
| `pages/report/[id].jsx` | Wrapped with ErrorBoundary |

## How to test

1. Temporarily uncomment this line inside `DashboardInner` in `pages/dashboard.jsx`, just before the `return`:
   ```js
   if (typeof window !== 'undefined') throw new Error('test render error')
   ```
2. **Client view** — sign in with a non-`@lyrise.ai` account, go to `/dashboard`, close the dev overlay → friendly apology screen + alert email fires to `mayar` and `amira`
3. **Employee view** — sign in with a `@lyrise.ai` account, same steps → detailed Render Error card with file location, component chain, and timestamp
4. Re-comment the line when done

> **Note:** Add other dev team emails to the `DEV_TEAM` array in `src/lib/notifyError.ts` to receive error alerts before merging ( I tested using only my own email)
