### PR TITLE
redirect: point ROI routes to roi.lyrise.ai

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,15 @@ module.exports = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  async redirects() {
+    return [
+      { source: '/dashboard', destination: 'https://roi.lyrise.ai/dashboard', permanent: false },
+      { source: '/roi-report', destination: 'https://roi.lyrise.ai/roi-report', permanent: false },
+      { source: '/roi-report/:path*', destination: 'https://roi.lyrise.ai/roi-report/:path*', permanent: false },
+      { source: '/report/:id', destination: 'https://roi.lyrise.ai/report/:id', permanent: false },
+      { source: '/roi-feedback', destination: 'https://roi.lyrise.ai/roi-feedback', permanent: false },
+    ]
+  },
   webpack: (config) => {
     config.resolve.alias = {
       ...config.resolve.alias,

--- a/src/components/MainLandingPage/HeroSection/index.jsx
+++ b/src/components/MainLandingPage/HeroSection/index.jsx
@@ -135,7 +135,7 @@ function HeroSection() {
           </div>
 
           <Link
-            href="/dashboard"
+            href="https://roi.lyrise.ai"
             className="inline-flex items-center justify-center px-8 py-4 text-lg font-semibold text-white transition-all transform bg-[#2C2C2C] rounded-full hover:bg-black hover:-translate-y-0.5 shadow-lg hover:shadow-gray-500/30 group"
           >
             Get Your ROI Breakdown


### PR DESCRIPTION
## Summary
- Updates the \"Get Your ROI Breakdown\" CTA in HeroSection to link directly to `https://roi.lyrise.ai`
- Adds server-side 307 redirects for all ROI routes so existing bookmarks, share links, and email links keep working:
  - `/dashboard` → `https://roi.lyrise.ai/dashboard`
  - `/roi-report` → `https://roi.lyrise.ai/roi-report`
  - `/report/:id` → `https://roi.lyrise.ai/report/:id`
  - `/roi-feedback` → `https://roi.lyrise.ai/roi-feedback`

## Deploy order
Merge this **after** `roi.lyrise.ai` is live and verified — otherwise the redirects will point nowhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)