### PR TITLE
Add ROI assumption verification flow

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,12 +6,36 @@ module.exports = {
     ignoreDuringBuilds: true,
   },
   async redirects() {
+    if (process.env.NODE_ENV !== 'production') {
+      return []
+    }
+
     return [
-      { source: '/dashboard', destination: 'https://roi.lyrise.ai/dashboard', permanent: false },
-      { source: '/roi-report', destination: 'https://roi.lyrise.ai/roi-report', permanent: false },
-      { source: '/roi-report/:path*', destination: 'https://roi.lyrise.ai/roi-report/:path*', permanent: false },
-      { source: '/report/:id', destination: 'https://roi.lyrise.ai/report/:id', permanent: false },
-      { source: '/roi-feedback', destination: 'https://roi.lyrise.ai/roi-feedback', permanent: false },
+      {
+        source: '/dashboard',
+        destination: 'https://roi.lyrise.ai/dashboard',
+        permanent: false,
+      },
+      {
+        source: '/roi-report',
+        destination: 'https://roi.lyrise.ai/roi-report',
+        permanent: false,
+      },
+      {
+        source: '/roi-report/:path*',
+        destination: 'https://roi.lyrise.ai/roi-report/:path*',
+        permanent: false,
+      },
+      {
+        source: '/report/:id',
+        destination: 'https://roi.lyrise.ai/report/:id',
+        permanent: false,
+      },
+      {
+        source: '/roi-feedback',
+        destination: 'https://roi.lyrise.ai/roi-feedback',
+        permanent: false,
+      },
     ]
   },
   webpack: (config) => {

--- a/pages/api/roi-agent.js
+++ b/pages/api/roi-agent.js
@@ -15,8 +15,12 @@
 import crypto from 'node:crypto'
 import { normalizeInput } from '@/src/lib/roi/pipeline/normalize'
 import { loadTemplate } from '@/src/lib/roi/pipeline/renderTemplate'
+import { roiCalculator } from '@/src/lib/roi/pipeline/roiCalculator'
 import { runReportAgent } from '@/src/lib/roi/agent'
-import { buildDevMockReportState } from '@/src/lib/roi/devMockReport'
+import {
+  buildDevMockReportState,
+  getCurrency,
+} from '@/src/lib/roi/devMockReport'
 import { generatePdf } from '@/src/lib/roi/services/pdf'
 import {
   sendReportEmail,
@@ -84,6 +88,188 @@ function buildShareUrl(req, reportId, token) {
   )}`
 }
 
+function createInitialReportState(normInput) {
+  return {
+    normInput,
+    company: null,
+    globals: null,
+    workflows: null,
+    copy: null,
+    calcOutput: null,
+    assembled: null,
+    renderedHtml: null,
+    renderedFullHtml: null,
+    confidenceLevel: null,
+    coreThesis: null,
+    painPoints: [],
+    researchSummary: null,
+    evidenceItems: [],
+    specificityAssessment: null,
+    salaryEvidence: [],
+  }
+}
+
+function stripFinalReportFields(state) {
+  return {
+    ...state,
+    copy: null,
+    assembled: null,
+    renderedHtml: null,
+    renderedFullHtml: null,
+    specificityAssessment: null,
+  }
+}
+
+function coercePositiveNumberOrNull(value) {
+  if (value === '' || value == null) return null
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric)) return Number.NaN
+  if (numeric <= 0) return Number.NaN
+  return numeric
+}
+
+function sanitizeOptionalString(value) {
+  if (value == null) return null
+  const text = String(value).trim()
+  return text || null
+}
+
+function applyVerificationPatch(state, verificationPatch = {}) {
+  if (
+    !state?.company ||
+    !state?.normInput ||
+    !state?.workflows ||
+    !state?.globals
+  ) {
+    throw new Error('Prepared report state is incomplete')
+  }
+
+  const companyPatch = verificationPatch.company ?? {}
+  const workflowPatches = Array.isArray(verificationPatch.workflows)
+    ? verificationPatch.workflows
+    : []
+
+  if ('employees' in companyPatch) {
+    const employees = coercePositiveNumberOrNull(companyPatch.employees)
+    if (Number.isNaN(employees)) {
+      throw new Error('Employee estimate must be a positive number')
+    }
+    state.company.employees = employees
+  }
+  if ('revenueEstimateM' in companyPatch) {
+    const revenueEstimateM = coercePositiveNumberOrNull(
+      companyPatch.revenueEstimateM,
+    )
+    if (Number.isNaN(revenueEstimateM)) {
+      throw new Error('Revenue estimate must be a positive number')
+    }
+    state.company.revenueEstimateM = revenueEstimateM
+  }
+  if ('industry' in companyPatch) {
+    state.company.industry = sanitizeOptionalString(companyPatch.industry) ?? ''
+  }
+  if ('country' in companyPatch) {
+    state.company.country = sanitizeOptionalString(companyPatch.country)
+  }
+  if ('teamSize' in companyPatch) {
+    state.normInput.teamSize =
+      sanitizeOptionalString(companyPatch.teamSize) ?? ''
+  }
+  if ('revenueRange' in companyPatch) {
+    state.normInput.revenueRange =
+      sanitizeOptionalString(companyPatch.revenueRange) ?? ''
+  }
+  if ('selectedCurrency' in companyPatch) {
+    const selectedCurrency =
+      sanitizeOptionalString(companyPatch.selectedCurrency) ?? ''
+    state.normInput.selectedCurrency = selectedCurrency
+    if (selectedCurrency) {
+      state.globals.currency = getCurrency(selectedCurrency)
+    }
+  }
+
+  workflowPatches.forEach((patch) => {
+    if (!patch || typeof patch !== 'object') return
+    const index = Number(patch.index)
+    if (
+      !Number.isInteger(index) ||
+      index < 0 ||
+      index >= state.workflows.length
+    ) {
+      throw new Error('Verification patch referenced an invalid workflow index')
+    }
+    const workflow = state.workflows[index]
+    if (
+      patch.originalName &&
+      String(patch.originalName).trim() !== workflow.name
+    ) {
+      throw new Error('Verification patch did not match the expected workflow')
+    }
+
+    const nextName = sanitizeOptionalString(patch.name)
+    if (nextName) workflow.name = nextName
+    const nextFunction = sanitizeOptionalString(patch.function)
+    if (nextFunction) workflow.function = nextFunction
+    const nextOwner = sanitizeOptionalString(patch.owner)
+    if (nextOwner) workflow.owner = nextOwner
+    const nextSeniority = sanitizeOptionalString(patch.seniorityLevel)
+    if (nextSeniority) workflow.seniorityLevel = nextSeniority
+    const nextSourceType = sanitizeOptionalString(patch.sourceType)
+    if (nextSourceType) workflow.sourceType = nextSourceType
+    const nextRationale = sanitizeOptionalString(patch.rationale)
+    if (nextRationale) workflow.rationale = nextRationale
+    ;[
+      'monthlyVolume',
+      'minutesPerItemBefore',
+      'minutesPerItemAfter',
+      'rateOverride',
+    ].forEach((field) => {
+      if (!(field in patch)) return
+      const numeric = coercePositiveNumberOrNull(patch[field])
+      if (Number.isNaN(numeric)) {
+        throw new Error(`${workflow.name}: ${field} must be a positive number`)
+      }
+      workflow[field] = numeric
+    })
+  })
+
+  const invalidWorkflow = state.workflows.find(
+    (workflow) =>
+      !sanitizeOptionalString(workflow.name) ||
+      !sanitizeOptionalString(workflow.function) ||
+      !sanitizeOptionalString(workflow.owner) ||
+      !sanitizeOptionalString(workflow.sourceType) ||
+      !sanitizeOptionalString(workflow.rationale) ||
+      !Number.isFinite(workflow.monthlyVolume) ||
+      workflow.monthlyVolume <= 0 ||
+      !Number.isFinite(workflow.minutesPerItemBefore) ||
+      workflow.minutesPerItemBefore <= 0 ||
+      !Number.isFinite(workflow.minutesPerItemAfter) ||
+      workflow.minutesPerItemAfter <= 0 ||
+      !Number.isFinite(workflow.rateOverride) ||
+      workflow.rateOverride <= 0,
+  )
+
+  if (invalidWorkflow) {
+    throw new Error(
+      `Workflow "${invalidWorkflow.name}" is missing one or more required fields`,
+    )
+  }
+
+  state.calcOutput = roiCalculator(
+    state.workflows,
+    state.globals,
+    state.company,
+  )
+  state.copy = null
+  state.assembled = null
+  state.renderedHtml = null
+  state.renderedFullHtml = null
+  state.specificityAssessment = null
+
+  return state
+}
+
 export default async function handler(req, res) {
   if (req.method === 'GET') {
     const supabase = createClient(req, res)
@@ -94,13 +280,22 @@ export default async function handler(req, res) {
       res.status(401).json({ error: 'Unauthorized' })
       return
     }
-    const { data: report } = await supabase
+    const reportId =
+      typeof req.query?.reportId === 'string' ? req.query.reportId : null
+    let reportQuery = supabase
       .from('reports')
-      .select('id, rendered_html, rendered_full_html, state_data')
+      .select(
+        'id, status, input_data, rendered_html, rendered_full_html, state_data',
+      )
       .eq('user_id', user.id)
-      .order('created_at', { ascending: false })
-      .limit(1)
-      .maybeSingle()
+    if (reportId) {
+      reportQuery = reportQuery.eq('id', reportId).limit(1)
+    } else {
+      reportQuery = reportQuery
+        .order('created_at', { ascending: false })
+        .limit(1)
+    }
+    const { data: report } = await reportQuery.maybeSingle()
 
     let messagesUsed = 0
     if (report) {
@@ -136,12 +331,14 @@ export default async function handler(req, res) {
     reportId,
     emailOverride,
     shareToken,
+    verificationPatch,
   } = req.body
 
-  if (!mode || !['generate', 'chat'].includes(mode)) {
-    res
-      .status(400)
-      .json({ error: 'Invalid mode. Must be "generate" or "chat".' })
+  if (!mode || !['generate', 'prepare', 'finalize', 'chat'].includes(mode)) {
+    res.status(400).json({
+      error:
+        'Invalid mode. Must be "generate", "prepare", "finalize", or "chat".',
+    })
     return
   }
 
@@ -289,30 +486,78 @@ export default async function handler(req, res) {
     persistedReport.share_message_count = claimedCount
   }
 
-  if (mode === 'generate') {
+  if (mode === 'generate' || mode === 'prepare' || mode === 'finalize') {
     const { data: genUserData } = await adminSupabase
       .from('users')
       .select('role')
       .eq('id', user.id)
       .single()
-    // fall back to email domain if the users row is missing or has wrong role
     const isEmployee =
       genUserData?.role === 'EMPLOYEE' ||
       user.email?.endsWith('@lyrise.ai') === true
 
-    if (!isEmployee) {
-      const { data: existingReport } = await supabase
+    if (!isEmployee && (mode === 'generate' || mode === 'prepare')) {
+      const { data: existingReports } = await supabase
         .from('reports')
-        .select('id')
+        .select('id, status')
         .eq('user_id', user.id)
-        .limit(1)
-        .maybeSingle()
-      if (existingReport) {
+        .order('created_at', { ascending: false })
+
+      const successReport = (existingReports ?? []).find(
+        (report) => report.status === 'SUCCESS',
+      )
+      if (successReport) {
         res
           .status(409)
-          .json({ error: 'report_exists', report_id: existingReport.id })
+          .json({ error: 'report_exists', report_id: successReport.id })
         return
       }
+
+      const pendingDraft = (existingReports ?? []).find(
+        (report) => report.status === 'PENDING_VERIFICATION',
+      )
+      if (
+        pendingDraft &&
+        (mode === 'generate' || !reportId || pendingDraft.id !== reportId)
+      ) {
+        res.status(409).json({
+          error: 'verification_pending',
+          report_id: pendingDraft.id,
+        })
+        return
+      }
+    }
+
+    if (mode === 'finalize') {
+      if (!reportId) {
+        res
+          .status(400)
+          .json({ error: 'reportId is required for finalize mode' })
+        return
+      }
+
+      const { data: report } = await adminSupabase
+        .from('reports')
+        .select(
+          'id, user_id, email, status, input_data, state_data, rendered_html, rendered_full_html, share_token',
+        )
+        .eq('id', reportId)
+        .single()
+
+      if (!report || report.user_id !== user.id) {
+        res.status(403).json({ error: 'Unauthorized' })
+        return
+      }
+
+      if (report.status !== 'PENDING_VERIFICATION') {
+        res.status(409).json({
+          error: 'report_not_pending_verification',
+          report_id: report.id,
+        })
+        return
+      }
+
+      persistedReport = report
     }
   }
 
@@ -341,46 +586,39 @@ export default async function handler(req, res) {
     const execTemplateHtml = loadTemplate('roi-exec-template.html')
     const fullTemplateHtml = loadTemplate('roi-template.html')
     const useDevMock =
-      IS_DEV && mode === 'generate' && devOptions?.skipLLM === true
+      IS_DEV &&
+      (mode === 'generate' || mode === 'prepare') &&
+      devOptions?.skipLLM === true
 
     let state
-    if (mode === 'generate') {
+    if (mode === 'generate' || mode === 'prepare') {
       const payload = mapFormToPayload(formData ?? req.body)
       const normInput = normalizeInput(payload)
 
       if (useDevMock) {
-        state = buildDevMockReportState({
+        const mockState = buildDevMockReportState({
           normInput,
           execTemplateHtml,
           fullTemplateHtml,
         })
+        state =
+          mode === 'prepare' ? stripFinalReportFields(mockState) : mockState
         send(res, {
           type: 'text_delta',
           delta:
             'Using dev mock report. Skipping research and LLM calls, but still saving the report.',
         })
-        send(res, { type: 'report_update', state })
+        if (mode === 'generate') {
+          send(res, { type: 'report_update', state })
+        }
       }
 
       if (!useDevMock) {
-        state = {
-          normInput,
-          company: null,
-          globals: null,
-          workflows: null,
-          copy: null,
-          calcOutput: null,
-          assembled: null,
-          renderedHtml: null,
-          renderedFullHtml: null,
-          confidenceLevel: null,
-          coreThesis: null,
-          painPoints: [],
-          researchSummary: null,
-          evidenceItems: [],
-          specificityAssessment: null,
-        }
+        state = createInitialReportState(normInput)
       }
+    } else if (mode === 'finalize') {
+      state = buildStateFromReportRow(persistedReport)
+      applyVerificationPatch(state, verificationPatch)
     } else {
       state = buildStateFromReportRow(persistedReport)
     }
@@ -394,7 +632,7 @@ export default async function handler(req, res) {
       ]
       send(res, {
         type: 'done',
-        assembled: true,
+        assembled: Boolean(state?.assembled),
         messages: capturedMessages,
       })
     } else {
@@ -406,6 +644,7 @@ export default async function handler(req, res) {
         templateHtml: execTemplateHtml,
         fullTemplateHtml,
         estimatesOnly: Boolean(devOptions?.estimatesOnly),
+        stopAfterFinancialModel: mode === 'prepare',
         abortSignal: abortController.signal,
         callbacks: {
           onTextDelta: (delta) => send(res, { type: 'text_delta', delta }),
@@ -557,10 +796,82 @@ export default async function handler(req, res) {
       }
     }
 
-    // Save report to DB after generation
-    let generatedShareToken = null
-    let savedReportId = null
-    if (mode === 'generate' && state.assembled) {
+    // Save report state after generation/finalization
+    let generatedShareToken = persistedReport?.share_token ?? null
+    let savedReportId = reportId ?? persistedReport?.id ?? null
+    if (mode === 'prepare' && state.calcOutput) {
+      const preparedState = stripFinalReportFields(state)
+      const { stateData } = splitStoredState(preparedState)
+      let savedDraft = null
+      let saveError = null
+
+      if (reportId) {
+        const result = await supabase
+          .from('reports')
+          .update({
+            company_name:
+              preparedState.company?.company ??
+              preparedState.normInput?.companyName ??
+              '',
+            email: preparedState.normInput?.email ?? '',
+            status: 'PENDING_VERIFICATION',
+            input_data: preparedState.normInput,
+            state_data: stateData,
+            rendered_html: null,
+            rendered_full_html: null,
+            completed_at: null,
+          })
+          .eq('id', reportId)
+          .eq('user_id', user.id)
+          .select('id')
+          .single()
+        savedDraft = result.data
+        saveError = result.error
+      } else {
+        const result = await supabase
+          .from('reports')
+          .insert({
+            user_id: user.id,
+            company_name:
+              preparedState.company?.company ??
+              preparedState.normInput?.companyName ??
+              '',
+            email: preparedState.normInput?.email ?? '',
+            status: 'PENDING_VERIFICATION',
+            input_data: preparedState.normInput,
+            state_data: stateData,
+          })
+          .select('id')
+          .single()
+        savedDraft = result.data
+        saveError = result.error
+      }
+
+      if (saveError) {
+        console.error('[roi-agent] draft save failed:', saveError)
+        send(res, {
+          type: 'error',
+          message: 'Failed to save prepared report: ' + saveError.message,
+        })
+        res.end()
+        return
+      }
+
+      if (savedDraft?.id) {
+        savedReportId = savedDraft.id
+        if (capturedUsage) {
+          await persistUsage(capturedUsage, {
+            reportId: savedDraft.id,
+            userId: user.id,
+          })
+        }
+        send(res, {
+          type: 'report_prepared',
+          report_id: savedDraft.id,
+          state: preparedState,
+        })
+      }
+    } else if (mode === 'generate' && state.assembled) {
       state.specificityAssessment = assessReportSpecificity(state)
 
       if (state.specificityAssessment.level === 'weak') {
@@ -606,11 +917,6 @@ export default async function handler(req, res) {
 
       if (savedReport?.id) {
         savedReportId = savedReport.id
-        // Persist LLM usage now that the report row (report_id) exists.
-        // Awaited (not fire-and-forget): on Vercel the serverless function can
-        // be frozen once the response ends, dropping un-awaited background
-        // writes. persistUsage swallows its own errors, so awaiting it can
-        // never block or fail generation.
         if (capturedUsage) {
           await persistUsage(capturedUsage, {
             reportId: savedReport.id,
@@ -635,13 +941,87 @@ export default async function handler(req, res) {
           })
         send(res, { type: 'report_saved', report_id: savedReport.id })
       }
+    } else if (mode === 'finalize' && state.assembled) {
+      state.specificityAssessment = assessReportSpecificity(state)
+
+      if (state.specificityAssessment.level === 'weak') {
+        send(res, {
+          type: 'text_delta',
+          delta:
+            '\n\nLow-confidence note: public company evidence was limited, so some workflow assumptions may still rely on benchmarks.',
+        })
+      }
+
+      const { stateData, renderedHtml, renderedFullHtml } =
+        splitStoredState(state)
+      generatedShareToken =
+        persistedReport?.share_token ??
+        crypto.randomBytes(24).toString('base64url')
+
+      const { error: updateError } = await supabase
+        .from('reports')
+        .update({
+          company_name:
+            state.assembled.roi_data?.company ??
+            state.normInput?.companyName ??
+            '',
+          email: state.normInput?.email ?? '',
+          status: 'SUCCESS',
+          input_data: state.normInput,
+          completed_at: new Date().toISOString(),
+          rendered_html: renderedHtml,
+          rendered_full_html: renderedFullHtml,
+          state_data: stateData,
+          share_token: generatedShareToken,
+        })
+        .eq('id', persistedReport.id)
+        .eq('user_id', user.id)
+
+      if (updateError) {
+        console.error('[roi-agent] finalize save failed:', updateError)
+        send(res, {
+          type: 'error',
+          message: 'Failed to finalize report: ' + updateError.message,
+        })
+        res.end()
+        return
+      }
+
+      savedReportId = persistedReport.id
+      if (capturedUsage) {
+        await persistUsage(capturedUsage, {
+          reportId: persistedReport.id,
+          userId: user.id,
+        })
+      }
+      await persistReportEvidence(
+        adminSupabase,
+        persistedReport.id,
+        state.evidenceItems,
+      )
+      adminSupabase
+        .from('events')
+        .insert({
+          user_id: user.id,
+          report_id: persistedReport.id,
+          type: 'report_created',
+        })
+        .then(({ error }) => {
+          if (error)
+            console.error('event insert failed (report_created)', error)
+        })
+      send(res, { type: 'report_saved', report_id: persistedReport.id })
     }
 
     // Fire-and-forget PDF + email after generation.
     // Skip when the client has disconnected: the report is still saved above
     // and reachable from the dashboard, but we don't auto-email a company a
     // report whose request was abandoned.
-    if (clientDisconnected && mode === 'generate' && state.assembled) {
+    if (
+      clientDisconnected &&
+      (mode === 'generate' || mode === 'finalize') &&
+      state.assembled
+    ) {
       console.warn(
         '[roi-agent] client gone — report saved but skipping PDF/email',
       )
@@ -649,7 +1029,7 @@ export default async function handler(req, res) {
     if (
       !IS_DEV &&
       !clientDisconnected &&
-      mode === 'generate' &&
+      (mode === 'generate' || mode === 'finalize') &&
       state.assembled &&
       state.renderedHtml &&
       state.normInput?.email

--- a/pages/roi-report.jsx
+++ b/pages/roi-report.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect, useRef } from 'react'
+import React, { useState, useCallback, useEffect, useMemo, useRef } from 'react'
 import Head from 'next/head'
 import { motion, AnimatePresence } from 'framer-motion'
 import { FaCheckCircle } from 'react-icons/fa'
@@ -6,11 +6,11 @@ import clsx from 'clsx'
 import MainHeader from '../src/layout/MainHeader'
 import LogosMarquee from '../src/components/MainLandingPage/LogosMarquee'
 import LastSection from '../src/components/MainLandingPage/LastSection'
+import AssumptionVerificationView from '../src/components/ROIGenerator/AssumptionVerificationView'
 import ReportLoadingScreen from '../src/components/ROIGenerator/ReportLoadingScreen'
-import ReportViewer from '../src/components/ROIGenerator/ReportViewer'
-import GeneratingView from '../src/components/ROIGenerator/GeneratingView'
 import { drainSSE } from '../src/lib/drainSSE'
 import { PIPELINE_LOG_TOOL_NAMES } from '../src/lib/roi/constants'
+import { roiCalculator } from '../src/lib/roi/pipeline/roiCalculator'
 import { useRouter } from 'next/router'
 import ErrorBoundary from '../src/components/shared/ErrorBoundary'
 
@@ -77,6 +77,18 @@ const REVENUE_OPTS = [
   '$200M+',
   'Prefer not to say',
 ]
+const CURRENCY_OPTIONS = CURRENCIES.map((label) => ({
+  label,
+  value: label.split(' – ')[0],
+}))
+const TEAM_SIZE_OPTIONS = TEAM_SIZE_OPTS.map((label) => ({
+  label,
+  value: label,
+}))
+const REVENUE_OPTIONS = REVENUE_OPTS.map((label) => ({
+  label,
+  value: label === 'Prefer not to say' ? '' : label,
+}))
 const TOTAL_STEPS = 2
 const IS_DEV = process.env.NODE_ENV === 'development'
 // Minimum time the loader stays visible (ms). Override via NEXT_PUBLIC_ROI_MIN_LOADER_MS.
@@ -86,6 +98,7 @@ const VIEW_STATES = {
   FORM: 'form',
   LOADING: 'loading',
   GENERATING: 'generating',
+  VERIFYING: 'verifying',
   FINALISING: 'finalising',
   COMPLETE: 'complete',
   SUCCESS: 'success',
@@ -124,6 +137,81 @@ function validateStep(step, s1, s2) {
     if (!s2.currency) errors.currency = 'Please select a currency'
   }
   return errors
+}
+
+function coerceNullablePositiveNumber(value) {
+  if (value === '' || value == null) return null
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric) || numeric <= 0) return null
+  return numeric
+}
+
+function buildVerificationPatch(baseState, draftState) {
+  return {
+    company: {
+      employees: coerceNullablePositiveNumber(draftState?.company?.employees),
+      revenueEstimateM: coerceNullablePositiveNumber(
+        draftState?.company?.revenueEstimateM,
+      ),
+      industry: draftState?.company?.industry ?? '',
+      country: draftState?.company?.country ?? '',
+      teamSize: draftState?.normInput?.teamSize ?? '',
+      revenueRange: draftState?.normInput?.revenueRange ?? '',
+      selectedCurrency: draftState?.normInput?.selectedCurrency ?? '',
+    },
+    workflows: (draftState?.workflows ?? []).map((workflow, index) => ({
+      index,
+      originalName: baseState?.workflows?.[index]?.name ?? workflow.name,
+      name: workflow.name ?? '',
+      function: workflow.function ?? '',
+      owner: workflow.owner ?? '',
+      monthlyVolume: coerceNullablePositiveNumber(workflow.monthlyVolume),
+      minutesPerItemBefore: coerceNullablePositiveNumber(
+        workflow.minutesPerItemBefore,
+      ),
+      minutesPerItemAfter: coerceNullablePositiveNumber(
+        workflow.minutesPerItemAfter,
+      ),
+      rateOverride: coerceNullablePositiveNumber(workflow.rateOverride),
+      seniorityLevel: workflow.seniorityLevel ?? '',
+      sourceType: workflow.sourceType ?? '',
+      rationale: workflow.rationale ?? '',
+    })),
+  }
+}
+
+function validateVerificationDraft(draftState) {
+  const errors = { company: {}, workflows: {} }
+
+  ;(draftState?.workflows ?? []).forEach((workflow, index) => {
+    const workflowErrors = {}
+    if (!workflow?.name?.trim()) workflowErrors.name = 'Required'
+    if (!workflow?.function?.trim()) workflowErrors.function = 'Required'
+    if (!workflow?.owner?.trim()) workflowErrors.owner = 'Required'
+    if (!workflow?.sourceType?.trim()) workflowErrors.sourceType = 'Required'
+    if (!workflow?.rationale?.trim()) workflowErrors.rationale = 'Required'
+    if (!coerceNullablePositiveNumber(workflow?.monthlyVolume)) {
+      workflowErrors.monthlyVolume = 'Enter a positive number'
+    }
+    if (!coerceNullablePositiveNumber(workflow?.minutesPerItemBefore)) {
+      workflowErrors.minutesPerItemBefore = 'Enter a positive number'
+    }
+    if (!coerceNullablePositiveNumber(workflow?.minutesPerItemAfter)) {
+      workflowErrors.minutesPerItemAfter = 'Enter a positive number'
+    }
+    if (!coerceNullablePositiveNumber(workflow?.rateOverride)) {
+      workflowErrors.rateOverride = 'Enter a positive number'
+    }
+    if (Object.keys(workflowErrors).length > 0) {
+      errors.workflows[index] = workflowErrors
+    }
+  })
+
+  const hasErrors =
+    Object.keys(errors.company).length > 0 ||
+    Object.keys(errors.workflows).length > 0
+
+  return hasErrors ? errors : null
 }
 
 // ── Shared UI ─────────────────────────────────────────────────────────────────
@@ -315,7 +403,8 @@ function Step2({ data, onChange, errors, isDev }) {
           Where should we send your report?
         </h2>
         <p className="text-sm text-gray-500">
-          Your report is generated and emailed — usually ready in 60 seconds.
+          We prepare the research first, then you confirm the assumptions before
+          we generate and email the final report.
         </p>
         {isDev && (
           <p className="mt-2 text-xs text-amber-600">
@@ -705,14 +794,17 @@ function ROIReportInner({ isEmployee }) {
   const [step, setStep] = useState(1)
   const [viewState, setViewState] = useState(VIEW_STATES.FORM)
 
-  const [isGenerationComplete, setIsGenerationComplete] = useState(false)
-  const generationStartedAt = useRef(Date.now())
+  const loaderStartedAt = useRef(Date.now())
   const [generationLog, setGenerationLog] = useState('')
   const [sseEvents, setSseEvents] = useState([])
   const [reportState, setReportState] = useState(null)
+  const [verificationState, setVerificationState] = useState(null)
+  const [verificationDraft, setVerificationDraft] = useState(null)
+  const [verificationReportId, setVerificationReportId] = useState(null)
+  const [verificationErrors, setVerificationErrors] = useState(null)
+  const [isRerunningResearch, setIsRerunningResearch] = useState(false)
   const [errorMessage, setErrorMessage] = useState('')
   const [reportId, setReportId] = useState(null)
-  const [initialMessagesUsed, setInitialMessagesUsed] = useState(0)
 
   const [s1, setS1] = useState(
     IS_DEV
@@ -737,6 +829,7 @@ function ROIReportInner({ isEmployee }) {
   const handleGenerationError = useCallback(
     (message) => {
       setErrorMessage(message)
+      setIsRerunningResearch(false)
       setViewState(VIEW_STATES.ERROR)
       if (!isEmployee) {
         fetch('/api/notify-error', {
@@ -744,8 +837,12 @@ function ROIReportInner({ isEmployee }) {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             error: message,
-            context: { page: 'roi-report', company: s1.companyName || '(unknown)' },
-            url: typeof window !== 'undefined' ? window.location.href : undefined,
+            context: {
+              page: 'roi-report',
+              company: s1.companyName || '(unknown)',
+            },
+            url:
+              typeof window !== 'undefined' ? window.location.href : undefined,
           }),
         }).catch(() => {})
       }
@@ -763,15 +860,71 @@ function ROIReportInner({ isEmployee }) {
     setErrors((prev) => ({ ...prev, [key]: '' }))
   }, [])
 
+  const verificationPreview = useMemo(() => {
+    if (
+      !verificationDraft?.company ||
+      !verificationDraft?.globals ||
+      !verificationDraft?.workflows
+    ) {
+      return verificationDraft?.calcOutput ?? null
+    }
+    try {
+      return roiCalculator(
+        verificationDraft.workflows,
+        verificationDraft.globals,
+        verificationDraft.company,
+      )
+    } catch {
+      return verificationDraft?.calcOutput ?? null
+    }
+  }, [verificationDraft])
+
+  const hydrateVerificationState = useCallback(async (existingReportId) => {
+    const existing = await fetch(`/api/roi-agent?reportId=${existingReportId}`)
+    if (!existing.ok) {
+      throw new Error('Could not load your prepared report. Please try again.')
+    }
+    const existingData = await existing.json()
+    if (!existingData?.report) {
+      throw new Error('Prepared report not found.')
+    }
+
+    const { buildStateFromReportRow } = await import(
+      '../src/lib/roi/reportState'
+    )
+    const builtState = buildStateFromReportRow(existingData.report)
+
+    if (existingData.report.status === 'PENDING_VERIFICATION') {
+      setVerificationReportId(existingData.report.id)
+      setVerificationState(builtState)
+      setVerificationDraft(JSON.parse(JSON.stringify(builtState)))
+      setVerificationErrors(null)
+      setIsRerunningResearch(false)
+      setViewState(VIEW_STATES.VERIFYING)
+      return
+    }
+
+    window.location.href = `/report/${existingData.report.id}`
+  }, [])
+
   const runGeneration = useCallback(
-    async ({ skipLLM = false, estimatesOnly = false } = {}) => {
-      generationStartedAt.current = Date.now()
-      setIsGenerationComplete(false)
+    async ({
+      skipLLM = false,
+      estimatesOnly = false,
+      existingReportId = null,
+      isRerun = false,
+    } = {}) => {
+      loaderStartedAt.current = Date.now()
       setViewState(VIEW_STATES.GENERATING)
       setGenerationLog('')
       setSseEvents([])
       setReportState(null)
+      setVerificationReportId(existingReportId)
+      setVerificationState(null)
+      setVerificationDraft(null)
+      setVerificationErrors(null)
       setErrorMessage('')
+      setIsRerunningResearch(isRerun)
 
       const payload = {
         'Company Name': s1.companyName.trim(),
@@ -795,8 +948,9 @@ function ROIReportInner({ isEmployee }) {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            mode: 'generate',
+            mode: 'prepare',
             formData: payload,
+            reportId: existingReportId,
             devOptions: { skipLLM, estimatesOnly },
           }),
         })
@@ -809,43 +963,12 @@ function ROIReportInner({ isEmployee }) {
         if (response.status === 409) {
           const data = await response.json()
           if (data.report_id) {
-            try {
-              const existing = await fetch('/api/roi-agent')
-              if (!existing.ok) {
-                // eslint-disable-next-line no-console -- intentional 409 fallback diagnostics
-                console.warn(
-                  'GET /api/roi-agent failed during 409 fallback:',
-                  existing.status,
-                )
-              } else {
-                const existingData = await existing.json()
-                if (existingData?.report?.rendered_html) {
-                  const { buildStateFromReportRow } = await import(
-                    '../src/lib/roi/reportState'
-                  )
-                  const builtState = buildStateFromReportRow(
-                    existingData.report,
-                  )
-                  setReportId(data.report_id)
-                  setReportState(builtState)
-                  setIsGenerationComplete(true)
-                  setViewState(VIEW_STATES.FINALISING)
-                  return
-                }
-              }
-            } catch (err) {
-              // eslint-disable-next-line no-console -- intentional 409 fallback diagnostics
-              console.warn(
-                'Failed to load existing report from 409 fallback:',
-                err,
-              )
-            }
-            window.location.href = `/report/${data.report_id}`
+            await hydrateVerificationState(data.report_id)
           }
           return
         }
 
-        let latestState = null
+        let preparedState = null
         await drainSSE(
           response.body.getReader(),
           new TextDecoder(),
@@ -863,36 +986,129 @@ function ROIReportInner({ isEmployee }) {
                 `${prev}\n${event.message}`.slice(-2000),
               )
               setSseEvents((prev) => [...prev, { text: event.message }])
-            } else if (event.type === 'report_update') {
-              latestState = event.state
-              setReportState(event.state)
-            } else if (event.type === 'report_saved') {
-              setReportId(event.report_id)
-            } else if (event.type === 'done') {
-              if (
-                (event.assembled || latestState?.assembled) &&
-                latestState?.renderedHtml
-              ) {
-                setIsGenerationComplete(true)
-                setViewState(VIEW_STATES.FINALISING)
-              } else {
-                handleGenerationError(
-                  'Report generation finished without a complete report.',
-                )
-              }
+            } else if (event.type === 'report_prepared') {
+              preparedState = event.state
+              setVerificationReportId(event.report_id)
+              setVerificationState(event.state)
+              setVerificationDraft(JSON.parse(JSON.stringify(event.state)))
+              setVerificationErrors(null)
+              setIsRerunningResearch(false)
+              setViewState(VIEW_STATES.VERIFYING)
             } else if (event.type === 'error') {
               throw new Error(event.message)
             }
           },
         )
+        if (!preparedState) {
+          handleGenerationError(
+            'Preparation finished without a verification state.',
+          )
+        }
       } catch (err) {
         handleGenerationError(
           err.message || 'Something went wrong. Please try again.',
         )
       }
     },
-    [s1, s2, handleGenerationError],
+    [handleGenerationError, hydrateVerificationState, s1, s2],
   )
+
+  const runFinalize = useCallback(async () => {
+    const validationErrors = validateVerificationDraft(verificationDraft)
+    if (validationErrors) {
+      setVerificationErrors(validationErrors)
+      return
+    }
+    if (!verificationReportId || !verificationState || !verificationDraft) {
+      handleGenerationError(
+        'Prepared report data is missing. Please re-run research.',
+      )
+      return
+    }
+
+    loaderStartedAt.current = Date.now()
+    setViewState(VIEW_STATES.FINALISING)
+    setGenerationLog('')
+    setSseEvents([{ text: 'Generating final report copy…' }])
+    setVerificationErrors(null)
+    setErrorMessage('')
+    setReportState(null)
+
+    try {
+      const response = await fetch('/api/roi-agent', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          mode: 'finalize',
+          reportId: verificationReportId,
+          verificationPatch: buildVerificationPatch(
+            verificationState,
+            verificationDraft,
+          ),
+        }),
+      })
+
+      if (response.status === 401) {
+        window.location.href = '/auth/login'
+        return
+      }
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}))
+        throw new Error(data?.error || `HTTP ${response.status}`)
+      }
+
+      let latestState = null
+      await drainSSE(response.body.getReader(), new TextDecoder(), (event) => {
+        if (event.type === 'text_delta') {
+          setGenerationLog((prev) => (prev + event.delta).slice(-2000))
+        } else if (event.type === 'tool_start') {
+          setGenerationLog((prev) => `${prev}\n[${event.tool}]`)
+          const line = sseEventToLogLine(event)
+          if (line) {
+            setSseEvents((prev) => [...prev, { text: line }])
+          }
+        } else if (event.type === 'pipeline_log') {
+          setGenerationLog((prev) => `${prev}\n${event.message}`.slice(-2000))
+          setSseEvents((prev) => [...prev, { text: event.message }])
+        } else if (event.type === 'report_update') {
+          latestState = event.state
+          setReportState(event.state)
+          setSseEvents((prev) => [
+            ...prev,
+            { text: 'Rendering report layout…' },
+          ])
+        } else if (event.type === 'report_saved') {
+          setReportId(event.report_id)
+          setSseEvents((prev) => [
+            ...prev,
+            { text: 'Report saved successfully. Opening report…' },
+          ])
+        } else if (event.type === 'done') {
+          setSseEvents((prev) => [
+            ...prev,
+            { text: 'Final report copy generated.' },
+          ])
+          if (!(event.assembled || latestState?.assembled)) {
+            handleGenerationError(
+              'Report finalization finished without a complete report.',
+            )
+          }
+        } else if (event.type === 'error') {
+          throw new Error(event.message)
+        }
+      })
+    } catch (err) {
+      handleGenerationError(
+        err.message || 'Something went wrong. Please try again.',
+      )
+    }
+  }, [
+    handleGenerationError,
+    verificationDraft,
+    verificationReportId,
+    verificationState,
+  ])
 
   // Finalisation lifecycle: enforce minimum visible loader duration, then
   // transition to COMPLETE once FINALISING and renderedHtml are available.
@@ -902,7 +1118,7 @@ function ROIReportInner({ isEmployee }) {
 
     let timeout
 
-    const elapsed = Date.now() - generationStartedAt.current
+    const elapsed = Date.now() - loaderStartedAt.current
     const remaining = Math.max(0, MIN_VISIBLE_DURATION - elapsed)
 
     // Force a paint cycle so the FINALISING state visually mounts
@@ -954,6 +1170,65 @@ function ROIReportInner({ isEmployee }) {
   const back = useCallback(() => {
     setStep((prev) => Math.max(prev - 1, 1))
     setErrors({})
+  }, [])
+
+  const changeVerificationCompanyField = useCallback((field, value) => {
+    setVerificationDraft((prev) => {
+      if (!prev) return prev
+      if (
+        field === 'teamSize' ||
+        field === 'revenueRange' ||
+        field === 'selectedCurrency'
+      ) {
+        return {
+          ...prev,
+          normInput: {
+            ...prev.normInput,
+            [field]: value,
+          },
+        }
+      }
+      return {
+        ...prev,
+        company: {
+          ...prev.company,
+          [field]: value,
+        },
+      }
+    })
+    setVerificationErrors((prev) =>
+      prev
+        ? {
+            ...prev,
+            company: { ...(prev.company ?? {}), [field]: undefined },
+          }
+        : prev,
+    )
+  }, [])
+
+  const changeVerificationWorkflowField = useCallback((index, field, value) => {
+    setVerificationDraft((prev) => {
+      if (!prev?.workflows?.[index]) return prev
+      return {
+        ...prev,
+        workflows: prev.workflows.map((workflow, workflowIndex) =>
+          workflowIndex === index ? { ...workflow, [field]: value } : workflow,
+        ),
+      }
+    })
+    setVerificationErrors((prev) => {
+      if (!prev?.workflows?.[index]) return prev
+      return {
+        ...prev,
+        workflows: {
+          ...prev.workflows,
+          [index]: {
+            ...prev.workflows[index],
+            [field]: undefined,
+          },
+        },
+      }
+    })
   }, [])
 
   // Non-form views
@@ -1029,6 +1304,41 @@ function ROIReportInner({ isEmployee }) {
           </div>
         </div>
       </div>
+    )
+  }
+
+  if (viewState === VIEW_STATES.VERIFYING && verificationDraft) {
+    return (
+      <>
+        <Head>
+          <title>Verify ROI Assumptions | LyRise</title>
+        </Head>
+        <MainHeader />
+        <AssumptionVerificationView
+          draftState={verificationDraft}
+          previewCalc={verificationPreview}
+          errors={verificationErrors}
+          teamSizeOptions={TEAM_SIZE_OPTIONS}
+          revenueOptions={REVENUE_OPTIONS}
+          currencyOptions={CURRENCY_OPTIONS}
+          onCompanyFieldChange={changeVerificationCompanyField}
+          onWorkflowFieldChange={changeVerificationWorkflowField}
+          onBack={() => {
+            setVerificationErrors(null)
+            setViewState(VIEW_STATES.FORM)
+          }}
+          onConfirm={runFinalize}
+          onRerun={() =>
+            runGeneration({
+              existingReportId: verificationReportId,
+              isRerun: true,
+            })
+          }
+          isSubmitting={viewState === VIEW_STATES.FINALISING}
+          isRerunning={isRerunningResearch}
+        />
+        <LastSection />
+      </>
     )
   }
 
@@ -1131,7 +1441,7 @@ function ROIReportInner({ isEmployee }) {
                     onClick={() => next({ skipLLM: true })}
                     className="px-5 py-2 text-sm font-semibold text-gray-700 transition-colors bg-gray-100 rounded-lg hover:bg-gray-200"
                   >
-                    Fast mock preview
+                    Prepare mock assumptions
                   </button>
                 )}
                 <button
@@ -1139,7 +1449,7 @@ function ROIReportInner({ isEmployee }) {
                   onClick={() => next()}
                   className="px-5 py-2 text-sm font-semibold text-white transition-colors bg-gray-900 rounded-lg shadow-sm hover:bg-gray-700"
                 >
-                  {step === TOTAL_STEPS ? 'Generate my report →' : 'Continue →'}
+                  {step === TOTAL_STEPS ? 'Review assumptions →' : 'Continue →'}
                 </button>
               </div>
             </div>
@@ -1156,11 +1466,10 @@ function ROIReportInner({ isEmployee }) {
 }
 
 export default function ROIReport(props) {
+  const { isEmployee } = props
+
   return (
-    <ErrorBoundary
-      isEmployee={props.isEmployee}
-      pageContext={{ page: 'roi-report' }}
-    >
+    <ErrorBoundary isEmployee={isEmployee} pageContext={{ page: 'roi-report' }}>
       <ROIReportInner {...props} />
     </ErrorBoundary>
   )

--- a/src/components/ROIGenerator/AssumptionVerificationView.jsx
+++ b/src/components/ROIGenerator/AssumptionVerificationView.jsx
@@ -1,0 +1,513 @@
+import clsx from 'clsx'
+
+function Field({ label, value, onChange, error, type = 'text', step }) {
+  return (
+    <label className="flex flex-col gap-1.5">
+      <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-gray-400">
+        {label}
+      </span>
+      <input
+        type={type}
+        value={value ?? ''}
+        onChange={(event) => onChange(event.target.value)}
+        step={step}
+        className={clsx(
+          'w-full rounded-xl border px-3 py-2.5 text-sm text-gray-900 outline-none transition-colors',
+          error
+            ? 'border-red-300 bg-red-50'
+            : 'border-gray-200 bg-white hover:border-gray-300 focus:border-gray-500',
+        )}
+      />
+      {error ? <span className="text-xs text-red-500">{error}</span> : null}
+    </label>
+  )
+}
+
+function SelectField({ label, value, onChange, options }) {
+  return (
+    <label className="flex flex-col gap-1.5">
+      <span className="text-[11px] font-semibold uppercase tracking-[0.14em] text-gray-400">
+        {label}
+      </span>
+      <select
+        value={value ?? ''}
+        onChange={(event) => onChange(event.target.value)}
+        className="w-full rounded-xl border border-gray-200 bg-white px-3 py-2.5 text-sm text-gray-900 outline-none transition-colors hover:border-gray-300 focus:border-gray-500"
+      >
+        <option value="">Select</option>
+        {options.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  )
+}
+
+function ContextPill({ label, value }) {
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white px-3 py-2">
+      <p className="text-[10px] font-semibold uppercase tracking-[0.14em] text-gray-400">
+        {label}
+      </p>
+      <p className="mt-1 truncate text-sm font-medium text-gray-700">
+        {value || 'Not set'}
+      </p>
+    </div>
+  )
+}
+
+function formatCurrency(value, currencyCode) {
+  if (value == null || Number.isNaN(Number(value))) return '—'
+  const code = currencyCode || 'USD'
+  try {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: code,
+      maximumFractionDigits: 0,
+    }).format(Number(value))
+  } catch {
+    return `${code} ${Math.round(Number(value)).toLocaleString()}`
+  }
+}
+
+function formatNumber(value) {
+  if (value == null || Number.isNaN(Number(value))) return '—'
+  return Math.round(Number(value)).toLocaleString()
+}
+
+function sourceMeta(sourceType) {
+  if (sourceType === 'research_derived') {
+    return {
+      label: 'Researched',
+      className: 'border-emerald-200 bg-emerald-50 text-emerald-700',
+    }
+  }
+  if (sourceType === 'user_stated') {
+    return {
+      label: 'Provided',
+      className: 'border-sky-200 bg-sky-50 text-sky-700',
+    }
+  }
+  return {
+    label: 'Benchmarked',
+    className: 'border-amber-200 bg-amber-50 text-amber-700',
+  }
+}
+
+export default function AssumptionVerificationView({
+  draftState,
+  previewCalc,
+  errors,
+  teamSizeOptions,
+  revenueOptions,
+  currencyOptions,
+  onCompanyFieldChange,
+  onWorkflowFieldChange,
+  onBack,
+  onConfirm,
+  onRerun,
+  isSubmitting,
+  isRerunning,
+}) {
+  const workflows = draftState?.workflows ?? []
+  const currencyCode =
+    draftState?.normInput?.selectedCurrency ??
+    draftState?.globals?.currency?.code ??
+    'USD'
+
+  return (
+    <div className="rebranding-landing-page -mt-[12px]">
+      <div className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-6 px-4 py-8 text-gray-900 md:px-6">
+        <div className="rounded-[28px] border border-gray-200 bg-white shadow-[0_24px_80px_rgba(15,23,42,0.08)]">
+          <div className="border-b border-gray-100 px-6 py-6 md:px-8">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-400">
+              Review assumptions
+            </p>
+            <h1 className="mt-2 text-2xl font-semibold tracking-tight text-gray-900 md:text-[2rem]">
+              Confirm the assumptions behind your ROI report
+            </h1>
+            <p className="mt-3 max-w-3xl text-sm leading-6 text-gray-500">
+              Check the numbers that drive the ROI calculation. Research notes
+              and source context stay tucked away unless you need them.
+            </p>
+          </div>
+
+          <div className="grid gap-6 px-6 py-6 md:px-8 lg:grid-cols-[minmax(0,1.6fr)_minmax(320px,0.9fr)]">
+            <div className="space-y-6">
+              <section className="rounded-2xl border border-gray-200 bg-gray-50/70 p-5">
+                <div className="flex items-center justify-between gap-4">
+                  <div>
+                    <h2 className="text-base font-semibold text-gray-900">
+                      Company anchors
+                    </h2>
+                    <p className="mt-1 text-sm text-gray-500">
+                      Quick sanity check for scale, revenue, and currency.
+                    </p>
+                  </div>
+                </div>
+
+                <div className="mt-5 grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                  <Field
+                    label="Employee estimate"
+                    type="number"
+                    step="1"
+                    value={draftState?.company?.employees ?? ''}
+                    error={errors?.company?.employees}
+                    onChange={(value) =>
+                      onCompanyFieldChange('employees', value)
+                    }
+                  />
+                  <Field
+                    label="Revenue estimate (M)"
+                    type="number"
+                    step="0.1"
+                    value={draftState?.company?.revenueEstimateM ?? ''}
+                    error={errors?.company?.revenueEstimateM}
+                    onChange={(value) =>
+                      onCompanyFieldChange('revenueEstimateM', value)
+                    }
+                  />
+                  <SelectField
+                    label="Team size band"
+                    value={draftState?.normInput?.teamSize ?? ''}
+                    options={teamSizeOptions}
+                    onChange={(value) =>
+                      onCompanyFieldChange('teamSize', value)
+                    }
+                  />
+                  <SelectField
+                    label="Revenue range"
+                    value={draftState?.normInput?.revenueRange ?? ''}
+                    options={revenueOptions}
+                    onChange={(value) =>
+                      onCompanyFieldChange('revenueRange', value)
+                    }
+                  />
+                  <SelectField
+                    label="Currency"
+                    value={draftState?.normInput?.selectedCurrency ?? ''}
+                    options={currencyOptions}
+                    onChange={(value) =>
+                      onCompanyFieldChange('selectedCurrency', value)
+                    }
+                  />
+                </div>
+
+                <details className="mt-4 rounded-xl border border-gray-200 bg-white px-4 py-3">
+                  <summary className="cursor-pointer text-sm font-medium text-gray-700">
+                    Benchmark context
+                  </summary>
+                  <div className="mt-3 grid gap-3 md:grid-cols-2">
+                    <Field
+                      label="Industry"
+                      value={draftState?.company?.industry ?? ''}
+                      onChange={(value) =>
+                        onCompanyFieldChange('industry', value)
+                      }
+                    />
+                    <Field
+                      label="Country"
+                      value={draftState?.company?.country ?? ''}
+                      onChange={(value) =>
+                        onCompanyFieldChange('country', value)
+                      }
+                    />
+                  </div>
+                </details>
+              </section>
+
+              <section className="space-y-4">
+                <div>
+                  <h2 className="text-base font-semibold text-gray-900">
+                    Workflow assumptions
+                  </h2>
+                  <p className="mt-1 text-sm text-gray-500">
+                    Review only the numeric inputs that shape the math. You can
+                    refine workflows and wording with the assistant after the
+                    report is generated.
+                  </p>
+                </div>
+
+                <div className="grid gap-4">
+                  {workflows.map((workflow, index) => {
+                    const meta = sourceMeta(workflow.sourceType)
+                    const workflowErrors = errors?.workflows?.[index] ?? {}
+
+                    return (
+                      <article
+                        key={`${workflow.name}-${index}`}
+                        className="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm"
+                      >
+                        <div className="flex flex-wrap items-start justify-between gap-3">
+                          <div className="min-w-[260px] flex-1">
+                            <p className="text-xs font-medium text-gray-400">
+                              Workflow {index + 1}
+                            </p>
+                            <h3 className="mt-1 text-lg font-semibold text-gray-900">
+                              {workflow.name || 'Untitled workflow'}
+                            </h3>
+                            <p className="mt-1 text-sm text-gray-500">
+                              Owner: {workflow.owner || 'Not set'}
+                            </p>
+                          </div>
+                          <span
+                            className={clsx(
+                              'inline-flex rounded-full border px-2.5 py-1 text-xs font-semibold',
+                              meta.className,
+                            )}
+                          >
+                            {meta.label}
+                          </span>
+                        </div>
+
+                        <div className="mt-4 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+                          <Field
+                            label="Monthly volume"
+                            type="number"
+                            step="1"
+                            value={workflow.monthlyVolume}
+                            error={workflowErrors.monthlyVolume}
+                            onChange={(value) =>
+                              onWorkflowFieldChange(
+                                index,
+                                'monthlyVolume',
+                                value,
+                              )
+                            }
+                          />
+                          <Field
+                            label="Minutes before AI"
+                            type="number"
+                            step="1"
+                            value={workflow.minutesPerItemBefore}
+                            error={workflowErrors.minutesPerItemBefore}
+                            onChange={(value) =>
+                              onWorkflowFieldChange(
+                                index,
+                                'minutesPerItemBefore',
+                                value,
+                              )
+                            }
+                          />
+                          <Field
+                            label="Minutes after AI"
+                            type="number"
+                            step="1"
+                            value={workflow.minutesPerItemAfter}
+                            error={workflowErrors.minutesPerItemAfter}
+                            onChange={(value) =>
+                              onWorkflowFieldChange(
+                                index,
+                                'minutesPerItemAfter',
+                                value,
+                              )
+                            }
+                          />
+                          <Field
+                            label="Hourly rate"
+                            type="number"
+                            step="0.1"
+                            value={workflow.rateOverride ?? ''}
+                            error={workflowErrors.rateOverride}
+                            onChange={(value) =>
+                              onWorkflowFieldChange(
+                                index,
+                                'rateOverride',
+                                value,
+                              )
+                            }
+                          />
+                        </div>
+
+                        <details className="mt-4 rounded-xl border border-gray-200 bg-gray-50 px-4 py-3">
+                          <summary className="cursor-pointer text-sm font-medium text-gray-700">
+                            More context
+                          </summary>
+                          <div className="mt-4 grid gap-4 md:grid-cols-3">
+                            <Field
+                              label="Workflow name"
+                              value={workflow.name}
+                              error={workflowErrors.name}
+                              onChange={(value) =>
+                                onWorkflowFieldChange(index, 'name', value)
+                              }
+                            />
+                            <Field
+                              label="Owner role"
+                              value={workflow.owner}
+                              error={workflowErrors.owner}
+                              onChange={(value) =>
+                                onWorkflowFieldChange(index, 'owner', value)
+                              }
+                            />
+                            <Field
+                              label="Function"
+                              value={workflow.function}
+                              error={workflowErrors.function}
+                              onChange={(value) =>
+                                onWorkflowFieldChange(index, 'function', value)
+                              }
+                            />
+                            <Field
+                              label="Seniority"
+                              value={workflow.seniorityLevel ?? ''}
+                              error={workflowErrors.seniorityLevel}
+                              onChange={(value) =>
+                                onWorkflowFieldChange(
+                                  index,
+                                  'seniorityLevel',
+                                  value,
+                                )
+                              }
+                            />
+                            <Field
+                              label="Source type"
+                              value={workflow.sourceType}
+                              error={workflowErrors.sourceType}
+                              onChange={(value) =>
+                                onWorkflowFieldChange(
+                                  index,
+                                  'sourceType',
+                                  value,
+                                )
+                              }
+                            />
+                          </div>
+                          <div className="mt-4 grid gap-3 md:grid-cols-3">
+                            <ContextPill
+                              label="Confidence"
+                              value={meta.label}
+                            />
+                            <ContextPill
+                              label="Original source"
+                              value={workflow.sourceType}
+                            />
+                            <ContextPill
+                              label="Benchmark role"
+                              value={workflow.seniorityLevel}
+                            />
+                          </div>
+                          <p className="mt-4 text-[11px] font-semibold uppercase tracking-[0.14em] text-gray-400">
+                            Why this estimate?
+                          </p>
+                          <textarea
+                            value={workflow.rationale ?? ''}
+                            onChange={(event) =>
+                              onWorkflowFieldChange(
+                                index,
+                                'rationale',
+                                event.target.value,
+                              )
+                            }
+                            className="mt-2 min-h-[88px] w-full rounded-xl border border-gray-200 bg-white px-3 py-2.5 text-sm text-gray-900 outline-none transition-colors hover:border-gray-300 focus:border-gray-500"
+                          />
+                          {workflowErrors.rationale ? (
+                            <p className="mt-2 text-xs text-red-500">
+                              {workflowErrors.rationale}
+                            </p>
+                          ) : null}
+                        </details>
+                      </article>
+                    )
+                  })}
+                </div>
+              </section>
+            </div>
+
+            <aside className="space-y-4">
+              <section className="rounded-2xl border border-gray-200 bg-[#0f172a] p-5 text-white shadow-[0_24px_60px_rgba(15,23,42,0.22)]">
+                <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                  Calculation preview
+                </p>
+                <div className="mt-4 grid gap-3">
+                  <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                    <p className="text-xs text-slate-400">
+                      Monthly hours returned
+                    </p>
+                    <p className="mt-2 text-2xl font-semibold tracking-tight">
+                      {formatNumber(previewCalc?.totalMonthlyHours)}
+                    </p>
+                  </div>
+                  <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                    <p className="text-xs text-slate-400">
+                      Annual hours returned
+                    </p>
+                    <p className="mt-2 text-2xl font-semibold tracking-tight">
+                      {formatNumber(previewCalc?.summary?.totalAnnualHours)}
+                    </p>
+                  </div>
+                  <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                    <p className="text-xs text-slate-400">
+                      Operational Dividend (12 mo)
+                    </p>
+                    <p className="mt-2 text-2xl font-semibold tracking-tight">
+                      {formatCurrency(
+                        previewCalc?.summary?.operationalDividend12mo,
+                        currencyCode,
+                      )}
+                    </p>
+                  </div>
+                  <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                    <p className="text-xs text-slate-400">
+                      Total Financial Gain (12 mo)
+                    </p>
+                    <p className="mt-2 text-2xl font-semibold tracking-tight">
+                      {formatCurrency(
+                        previewCalc?.summary?.totalFinancialGain12mo,
+                        currencyCode,
+                      )}
+                    </p>
+                  </div>
+                </div>
+              </section>
+
+              <section className="rounded-2xl border border-gray-200 bg-gray-50 p-5">
+                <p className="text-sm font-medium text-gray-900">
+                  What happens next
+                </p>
+                <p className="mt-2 text-sm leading-6 text-gray-500">
+                  Once you confirm, we will generate the narrative sections,
+                  render the report, save evidence, and send the PDF and email.
+                  After that, the AI assistant can still change workflows,
+                  rewrite report sections, adjust tone, or explain the numbers.
+                </p>
+              </section>
+            </aside>
+          </div>
+
+          <div className="flex flex-col gap-3 border-t border-gray-100 px-6 py-5 md:flex-row md:items-center md:justify-between md:px-8">
+            <button
+              type="button"
+              onClick={onBack}
+              className="rounded-xl border border-gray-200 px-4 py-2.5 text-sm font-medium text-gray-600 transition-colors hover:border-gray-400 hover:text-gray-900"
+            >
+              Back to intake
+            </button>
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <button
+                type="button"
+                onClick={onRerun}
+                disabled={isSubmitting || isRerunning}
+                className="rounded-xl border border-gray-200 px-4 py-2.5 text-sm font-medium text-gray-600 transition-colors hover:border-gray-400 hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {isRerunning ? 'Re-running research…' : 'Re-run research'}
+              </button>
+              <button
+                type="button"
+                onClick={onConfirm}
+                disabled={isSubmitting || isRerunning}
+                className="rounded-xl bg-gray-900 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-gray-700 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {isSubmitting
+                  ? 'Creating report…'
+                  : 'Confirm and create report'}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/ROIGenerator/ReportLoadingScreen.jsx
+++ b/src/components/ROIGenerator/ReportLoadingScreen.jsx
@@ -45,7 +45,7 @@ const PHASE_IDLE_ADVANCE_MS = 45000
 const MIN_LOG_GAP_MS = 2500
 
 const PIPELINE_MILESTONE_RE =
-  /^(Research complete|Calibrating ROI|Refining model assumptions|3-year financial|Writing profit|Rendering financial)/i
+  /^(Research complete|Calibrating ROI|Refining model assumptions|3-year financial|Writing profit|Rendering financial|Generating final report copy|Final report copy generated|Rendering report layout|Report saved successfully|Opening report)/i
 
 // Rotating messages from web_search pools in agent.ts — collapse to one summary line
 const SEARCH_POOL_RE =
@@ -100,6 +100,12 @@ export default function ReportLoadingScreen({
   const isComplete = viewState === 'complete'
   const isDoneOrFinalising = isFinalising || isComplete
 
+  useEffect(() => {
+    if (isFinalising) {
+      setPhaseIndex(PHASES.length - 1)
+    }
+  }, [isFinalising])
+
   // Phase auto-advance — idle fallback only; real pipeline_log drives phases first
   useEffect(() => {
     if (isDoneOrFinalising || sseEvents.length > 0) return () => {}
@@ -112,7 +118,7 @@ export default function ReportLoadingScreen({
 
   // Drive phase from real pipeline_log / tool milestones (falls back to generationLog)
   useEffect(() => {
-    if (isDoneOrFinalising) return
+    if (isComplete) return
     const signal = [...sseEvents.map((e) => e.text), generationLog]
       .join('\n')
       .toLowerCase()
@@ -133,11 +139,11 @@ export default function ReportLoadingScreen({
     ) {
       setPhaseIndex(1)
     }
-  }, [generationLog, sseEvents, phaseIndex, isDoneOrFinalising])
+  }, [generationLog, sseEvents, phaseIndex, isComplete])
 
   // Process new pipeline_log events — parallel tool calls burst in the same second
   useEffect(() => {
-    if (!sseEvents.length || isDoneOrFinalising) return
+    if (!sseEvents.length || isComplete) return
 
     const pending = sseEvents.slice(lastProcessedSseIndex.current)
     if (!pending.length) return
@@ -186,7 +192,7 @@ export default function ReportLoadingScreen({
       lastLogAppendAt.current = lastAppendAt
       return next
     })
-  }, [sseEvents, activePhase, isDoneOrFinalising])
+  }, [sseEvents, activePhase, isComplete])
 
   // Elapsed timer
   useEffect(() => {
@@ -200,18 +206,39 @@ export default function ReportLoadingScreen({
 
   // Idle placeholder — one line until real pipeline_log arrives; no cycling
   useEffect(() => {
-    if (isDoneOrFinalising) {
+    if (isComplete) {
       logId.current += 1
       setLogs((prev) => {
-        if (prev.length > 0 && prev[prev.length - 1].phase === 'finalising') {
+        if (prev.length > 0 && prev[prev.length - 1].phase === 'complete') {
           return prev
         }
         return [
           ...prev,
           {
             id: logId.current,
-            phase: 'finalising',
-            text: '✓ Report assembled successfully',
+            phase: 'complete',
+            text: 'Opening report…',
+            time: nowLabel(),
+          },
+        ].slice(-MAX_LOG_LINES)
+      })
+      return () => {}
+    }
+
+    if (isFinalising && sseEvents.length === 0) {
+      logId.current += 1
+      setLogs((prev) => {
+        if (
+          prev.some((entry) => entry.text === 'Generating final report copy…')
+        ) {
+          return prev
+        }
+        return [
+          ...prev,
+          {
+            id: logId.current,
+            phase: 'report',
+            text: 'Generating final report copy…',
             time: nowLabel(),
           },
         ].slice(-MAX_LOG_LINES)
@@ -242,7 +269,7 @@ export default function ReportLoadingScreen({
       ].slice(-MAX_LOG_LINES)
     })
     return undefined
-  }, [activePhase, isDoneOrFinalising, sseEvents.length])
+  }, [activePhase, isComplete, isFinalising, sseEvents.length])
 
   const timeLabel = useMemo(() => {
     const m = String(Math.floor(elapsed / 60)).padStart(2, '0')
@@ -389,7 +416,7 @@ export default function ReportLoadingScreen({
               logs={logs}
               phaseIndex={phaseIndex}
               elapsed={elapsed}
-              isFinalising={isDoneOrFinalising}
+              isComplete={isComplete}
             />
           </div>
 
@@ -480,7 +507,7 @@ function PhaseDot({ state }) {
   )
 }
 
-function ActivityLog({ logs, phaseIndex, elapsed, isFinalising }) {
+function ActivityLog({ logs, phaseIndex, elapsed, isComplete }) {
   const phaseActivityLabels = [
     'Data Collection',
     'Financial Modelling',
@@ -504,7 +531,7 @@ function ActivityLog({ logs, phaseIndex, elapsed, isFinalising }) {
           <span
             className={
               'h-[6px] w-[6px] rounded-full ' +
-              (isFinalising ? 'bg-gray-500' : 'bg-primary opacity-75')
+              (isComplete ? 'bg-gray-500' : 'bg-primary opacity-75')
             }
           />
           <span className="font-mono text-[10px] uppercase tracking-[0.18em] text-terminal-fg opacity-55">
@@ -513,7 +540,7 @@ function ActivityLog({ logs, phaseIndex, elapsed, isFinalising }) {
         </div>
         <div className="flex items-center gap-3">
           <span className="font-mono text-[10px] text-terminal-muted">
-            {isFinalising
+            {isComplete
               ? 'Finalised'
               : `Phase ${phaseIndex + 1}/${
                   PHASES.length
@@ -567,13 +594,11 @@ function ActivityLog({ logs, phaseIndex, elapsed, isFinalising }) {
           <span
             className={
               'h-1 w-1 rounded-full ' +
-              (isFinalising
-                ? 'bg-gray-500 opacity-40'
-                : 'bg-primary opacity-60')
+              (isComplete ? 'bg-gray-500 opacity-40' : 'bg-primary opacity-60')
             }
           />
           <span className="font-mono text-[9.5px] text-terminal-muted opacity-60">
-            {isFinalising ? 'done' : 'live'}
+            {isComplete ? 'done' : 'live'}
           </span>
         </div>
       </div>

--- a/src/lib/roi/agent.ts
+++ b/src/lib/roi/agent.ts
@@ -240,11 +240,17 @@ function buildTools(
         })
         if (SALARY_SEARCH_RE.test(query)) {
           // eslint-disable-next-line security/detect-object-injection
-          callbacks.onPipelineLog?.(SALARY_SEARCH_POOL[salarySearchCount % SALARY_SEARCH_POOL.length])
+          callbacks.onPipelineLog?.(
+            SALARY_SEARCH_POOL[salarySearchCount % SALARY_SEARCH_POOL.length],
+          )
           salarySearchCount++
         } else {
           // eslint-disable-next-line security/detect-object-injection
-          callbacks.onPipelineLog?.(COMPANY_SEARCH_POOL[companySearchCount % COMPANY_SEARCH_POOL.length])
+          callbacks.onPipelineLog?.(
+            COMPANY_SEARCH_POOL[
+              companySearchCount % COMPANY_SEARCH_POOL.length
+            ],
+          )
           companySearchCount++
         }
         const response = await webSearch(query, maxResults ?? 3)
@@ -464,7 +470,9 @@ function buildTools(
       }),
       execute: async (input) => {
         const cp = input.company_profile
-        callbacks.onPipelineLog?.(`Research complete — ${input.workflows.length} workflows identified…`)
+        callbacks.onPipelineLog?.(
+          `Research complete — ${input.workflows.length} workflows identified…`,
+        )
         roiLog('tool:set_research', `locking research for ${cp.company}`, {
           industry: cp.industry,
           country: cp.country,
@@ -713,7 +721,8 @@ function buildTools(
             retryHint = `\n\nPREVIOUS ATTEMPT FAILED: ${lastError}.${prescription}`
           }
 
-          if (attempt > 0) callbacks.onPipelineLog?.('Refining model assumptions…')
+          if (attempt > 0)
+            callbacks.onPipelineLog?.('Refining model assumptions…')
           roiLog(
             'modeler',
             `attempt ${attempt + 1}/3${attempt > 0 ? ' (retry)' : ''}`,
@@ -969,7 +978,9 @@ function buildTools(
       }),
       execute: async (copy: ReportCopy) => {
         state.copy = copy
-        callbacks.onPipelineLog?.('Writing profit levers and executive summary…')
+        callbacks.onPipelineLog?.(
+          'Writing profit levers and executive summary…',
+        )
         reAssemble(state, execTemplateHtml, fullTemplateHtml, callbacks, [
           'thesis',
           'workflows',
@@ -1492,7 +1503,12 @@ function buildTools(
 function buildGenerationSystemPrompt(
   companyName: string,
   estimatesOnly = false,
+  stopAfterFinancialModel = false,
 ): string {
+  const nextStepInstruction = stopAfterFinancialModel
+    ? 'Then: run_financial_model() and stop. Do NOT call set_report_copy.'
+    : 'Then: run_financial_model() → set_report_copy(…)'
+
   if (estimatesOnly) {
     return `You are the LyRise ROI Report Agent. Generate an estimate-based report for ${companyName}.
 
@@ -1504,9 +1520,15 @@ YOUR FIRST ACTION: call set_research_output immediately with:
 - confidenceLevel: 'low'
 - A clear coreThesis based on the company description
 
-Then: run_financial_model() → set_report_copy(…)
+${nextStepInstruction}
 
 Do not write any text before calling set_research_output. Act immediately.
+
+${
+  stopAfterFinancialModel
+    ? 'This is a preparation-only run. End immediately after run_financial_model succeeds.'
+    : ''
+}
 
 MANDATORY for set_report_copy:
 • unified_pattern_thesis (KR-16): 2-3 sentences naming SINGLE operating pattern
@@ -1577,7 +1599,11 @@ Every text field you emit (whyItMatters, volumeRationale, expectedOutcome, resea
 Each sentence must reference at least one of: the company's actual product/service, its industry sub-vertical, its country/region, an observed tool/system, a stated client type, a regulatory or competitive context surfaced from research, or a numeric signal (headcount, transaction volume, geographic footprint). If you cannot tie a sentence to a concrete signal, delete it rather than pad.
 
 After phases 1–6, call tools in order:
-  set_research_output(…) → run_financial_model() → set_report_copy(…)
+  ${
+    stopAfterFinancialModel
+      ? 'set_research_output(…) → run_financial_model()'
+      : 'set_research_output(…) → run_financial_model() → set_report_copy(…)'
+  }
 
 MANDATORY for set_report_copy:
 • unified_pattern_thesis (KR-16): 2-3 sentences naming SINGLE operating pattern, no workflow lists
@@ -1597,15 +1623,113 @@ TERMINOLOGY (mandatory):
 • "Hours Returned" — never "time saved"
 
 ABSOLUTE PIPELINE REQUIREMENT:
-You MUST call set_research_output → run_financial_model → set_report_copy in sequence, without exception.
+You MUST call ${
+    stopAfterFinancialModel
+      ? 'set_research_output → run_financial_model'
+      : 'set_research_output → run_financial_model → set_report_copy'
+  } in sequence, without exception.
 If all web searches fail or return no useful data: STOP researching and call set_research_output IMMEDIATELY using the questionnaire inputs and industry benchmarks, with confidenceLevel: 'low' and sourceType: 'inferred' for all workflows.
 NEVER end generation with only text. NEVER explain why you couldn't research. If stuck: call set_research_output NOW.
+${
+  stopAfterFinancialModel
+    ? '\nThis request is preparation-only. Once run_financial_model succeeds, stop immediately without writing report copy.'
+    : ''
+}
 
 WORKFLOWS REQUIREMENT (critical):
 • set_research_output.workflows MUST contain EXACTLY 4 workflows — not 3, not 5
 • Every workflow MUST have monthlyVolume > 0 (use industry benchmarks if unknown — e.g. 200/mo for a 50-person firm)
 • Every workflow MUST have minutesPerItemBefore > 0 and minutesPerItemAfter > 0
 • Infer realistic volumes from team size and industry — do NOT submit 0 or omit these fields`
+}
+
+function buildFinalizeSystemPrompt(state: ReportState): string {
+  const company = state.company
+  const globals = state.globals
+  const workflows = state.workflows ?? []
+  const calc = state.calcOutput
+
+  if (!company || !globals || !calc) {
+    throw new Error(
+      'Finalize mode requires prepared company, workflow, and calculator state',
+    )
+  }
+
+  const currencySymbol =
+    globals.currency?.symbol ?? globals.currency?.code ?? '$'
+  const workflowLines = workflows
+    .map((workflow, index) => {
+      const calcWorkflow = calc.workflows[index]
+      return `${index + 1}. ${workflow.name}
+- Function: ${workflow.function}
+- Owner: ${workflow.owner}
+- Monthly volume: ${workflow.monthlyVolume}
+- Minutes before AI: ${workflow.minutesPerItemBefore}
+- Minutes after AI: ${workflow.minutesPerItemAfter}
+- Hourly rate: ${workflow.rateOverride ?? globals.laborRate}
+- Seniority: ${workflow.seniorityLevel ?? 'mid'}
+- Source type: ${workflow.sourceType}
+- Rationale: ${workflow.rationale}
+- Annual hours returned: ${Math.round(calcWorkflow?.annualHours ?? 0)}
+- Annual value: ${Math.round(calcWorkflow?.annualValue ?? 0)}`
+    })
+    .join('\n\n')
+
+  const painPointLines = (state.painPoints ?? [])
+    .map(
+      (point) =>
+        `- ${point.title} (${point.confidence}, ${point.source}): ${point.description}`,
+    )
+    .join('\n')
+
+  return `You are the LyRise ROI Report Finalizer.
+
+This report has already completed research and financial modeling. Do NOT call set_research_output. Do NOT call run_financial_model. Do NOT call web_search or fetch_page. Do NOT explain your plan in plain text.
+
+Your only job is to author the final report copy by calling set_report_copy exactly once.
+
+Company:
+- Name: ${company.company}
+- Industry: ${company.industry}
+- Country: ${company.country ?? 'Unknown'}
+- Employees: ${company.employees ?? 'Unknown'}
+- Revenue estimate (millions): ${company.revenueEstimateM ?? 'Unknown'}
+- Confidence: ${state.confidenceLevel ?? 'low'}
+- Thesis anchor: ${state.coreThesis ?? ''}
+- Research summary: ${state.researchSummary ?? ''}
+
+Pain points:
+${painPointLines || '- None recorded'}
+
+Workflows:
+${workflowLines}
+
+Calculated totals:
+- Total monthly hours returned: ${Math.round(calc.totalMonthlyHours)}
+- Total annual hours returned: ${Math.round(calc.summary.totalAnnualHours)}
+- Operational Dividend (12 mo): ${currencySymbol}${Math.round(
+    calc.summary.operationalDividend12mo,
+  )}
+- Total Financial Gain (12 mo): ${currencySymbol}${Math.round(
+    calc.summary.totalFinancialGain12mo,
+  )}
+
+MANDATORY for set_report_copy:
+- unified_pattern_thesis: 2-3 sentences naming a single operating pattern
+- company_snapshot: 3-5 bullets with source tags
+- profit_levers: exactly 4 items, one per workflow in the same order
+- cost_of_delay.narrative: no dollar figure, must end with "Delay is not neutral â€” it carries a monthly price."
+- resilience_rows: exactly 4 rows with dimensions Cost per unit, Delivery speed, Error rate, Strategic capacity
+- pilot_recommendation: must reference specific company characteristics
+- risks: at least 3 company-specific rows
+- cta_paragraph: criteria-based, not salesy
+
+Terminology:
+- "Operational Dividend", never "cost savings"
+- "Total Financial Gain", never "ROI"
+- "Hours Returned", never "time saved"
+
+Call set_report_copy now and then stop.`
 }
 
 function buildChatSystemPrompt(state: ReportState): string {
@@ -1887,7 +2011,7 @@ STRICT RULES:
 // ── Main entry point ──────────────────────────────────────────────────────────
 
 export async function runReportAgent(params: {
-  mode: 'generate' | 'chat'
+  mode: 'generate' | 'prepare' | 'finalize' | 'chat'
   state: ReportState
   message?: string
   chatHistory?: ModelMessage[]
@@ -1895,6 +2019,7 @@ export async function runReportAgent(params: {
   templateHtml: string
   fullTemplateHtml: string
   estimatesOnly?: boolean
+  stopAfterFinancialModel?: boolean
   // Aborts the streamText loop when the caller (e.g. an HTTP client) goes away,
   // so we stop burning tokens on a report nobody is waiting on.
   abortSignal?: AbortSignal
@@ -1908,12 +2033,14 @@ export async function runReportAgent(params: {
     templateHtml,
     fullTemplateHtml,
     estimatesOnly = false,
+    stopAfterFinancialModel = false,
     abortSignal,
   } = params
 
   const company = state.normInput?.companyName ?? 'unknown'
   roiLog('agent', `▶ runReportAgent mode=${mode} company="${company}"`, {
     estimatesOnly,
+    stopAfterFinancialModel,
     country: state.normInput?.country,
     industry: state.normInput?.industry,
     teamSize: state.normInput?.teamSize,
@@ -1927,18 +2054,24 @@ export async function runReportAgent(params: {
     )
   }
   const tracker = new UsageTracker({ company, mode })
-  const tools = buildTools(
+  const allTools = buildTools(
     state,
     templateHtml,
     fullTemplateHtml,
     callbacks,
     tracker,
   )
+  const tools =
+    mode === 'finalize'
+      ? { set_report_copy: allTools.set_report_copy }
+      : (mode === 'generate' || mode === 'prepare') && stopAfterFinancialModel
+      ? (({ set_report_copy, ...prepareTools }) => prepareTools)(allTools)
+      : allTools
 
   let system: string
   let messages: ModelMessage[]
 
-  if (mode === 'generate') {
+  if (mode === 'generate' || mode === 'prepare') {
     const companyName = state.normInput.companyName
     const website = state.normInput.website
     const desc = state.normInput.businessDescription
@@ -1950,11 +2083,19 @@ export async function runReportAgent(params: {
         }`
       : ''
 
-    system = buildGenerationSystemPrompt(companyName, estimatesOnly)
+    system = buildGenerationSystemPrompt(
+      companyName,
+      estimatesOnly,
+      stopAfterFinancialModel,
+    )
     messages = [
       {
         role: 'user',
-        content: `Generate a complete ROI report for ${companyName}.
+        content: `Generate a ${
+          stopAfterFinancialModel
+            ? 'prepared ROI assumptions package'
+            : 'complete ROI report'
+        } for ${companyName}.
 Website: ${website}
 Description: ${desc}
 ${recip ? 'Recipient: ' + recip : ''}
@@ -1968,6 +2109,22 @@ ${
   state.normInput.workContext ? 'Context: ' + state.normInput.workContext : ''
 }`,
       },
+    ]
+  } else if (mode === 'finalize') {
+    if (
+      !state.company ||
+      !state.globals ||
+      !state.workflows ||
+      !state.calcOutput
+    ) {
+      callbacks.onError(
+        new Error('Finalize mode requires a prepared report state'),
+      )
+      return
+    }
+    system = buildFinalizeSystemPrompt(state)
+    messages = [
+      { role: 'user', content: 'Generate the final report copy now.' },
     ]
   } else {
     // Chat mode — state must have calcOutput + copy
@@ -1989,7 +2146,7 @@ ${
     system,
     messages,
     tools,
-    stopWhen: stepCountIs(mode === 'generate' ? 24 : 8),
+    stopWhen: stepCountIs(mode === 'generate' || mode === 'prepare' ? 24 : 8),
     abortSignal,
   })
 
@@ -1998,7 +2155,10 @@ ${
       if (part.type === 'text-delta') {
         callbacks.onTextDelta(part.text)
       } else if (part.type === 'tool-call') {
-        callbacks.onToolStart(part.toolName, part.input as Record<string, unknown>)
+        callbacks.onToolStart(
+          part.toolName,
+          part.input as Record<string, unknown>,
+        )
       } else if (part.type === 'error') {
         // An abort surfaces here as an error part — treat it as a clean stop,
         // not a generation failure, so the caller doesn't persist/email it.
@@ -2036,7 +2196,7 @@ ${
   // agent runs, so the agent itself has no report_id to write.
   callbacks.onUsage?.(tracker.flush())
 
-  if (mode === 'generate' && !state.assembled) {
+  if ((mode === 'generate' || mode === 'finalize') && !state.assembled) {
     const done =
       [
         state.company ? 'research' : null,
@@ -2065,6 +2225,16 @@ ${
             : ''
         }`,
       ),
+    )
+    return
+  }
+
+  if (
+    mode === 'prepare' &&
+    (!state.company || !state.globals || !state.calcOutput)
+  ) {
+    callbacks.onError(
+      new Error('Preparation completed without a financial model state'),
     )
     return
   }

--- a/src/lib/roi/devMockReport.ts
+++ b/src/lib/roi/devMockReport.ts
@@ -18,10 +18,16 @@ const CURRENCY_MAP: Record<string, Currency> = {
   GBP: { code: 'GBP', symbol: 'GBP ', name: 'British Pound' },
   SAR: { code: 'SAR', symbol: 'ر.س', name: 'Saudi Riyal' },
   AED: { code: 'AED', symbol: 'د.إ', name: 'UAE Dirham' },
+  QAR: { code: 'QAR', symbol: 'QAR ', name: 'Qatari Riyal' },
+  KWD: { code: 'KWD', symbol: 'KWD ', name: 'Kuwaiti Dinar' },
+  BHD: { code: 'BHD', symbol: 'BHD ', name: 'Bahraini Dinar' },
+  OMR: { code: 'OMR', symbol: 'OMR ', name: 'Omani Rial' },
   EGP: { code: 'EGP', symbol: 'EGP ', name: 'Egyptian Pound' },
+  NGN: { code: 'NGN', symbol: 'NGN ', name: 'Nigerian Naira' },
+  ZAR: { code: 'ZAR', symbol: 'ZAR ', name: 'South African Rand' },
 }
 
-function getCurrency(code: string): Currency {
+export function getCurrency(code: string): Currency {
   return CURRENCY_MAP[code] ?? CURRENCY_MAP.USD
 }
 

--- a/src/lib/roi/services/usageStore.ts
+++ b/src/lib/roi/services/usageStore.ts
@@ -15,6 +15,10 @@ import { supabaseAdmin } from '@/src/lib/supabaseAdmin'
 import { maybeSendUsageCostAlert } from './usageAlerts'
 import type { UsageSummary } from './usageTracker'
 
+function persistedModeFor(summary: UsageSummary): 'generate' | 'chat' {
+  return summary.mode === 'chat' ? 'chat' : 'generate'
+}
+
 export async function persistUsage(
   summary: UsageSummary,
   ids: { reportId: string; userId?: string | null },
@@ -26,6 +30,8 @@ export async function persistUsage(
     return
   }
   try {
+    const persistedMode = persistedModeFor(summary)
+
     // Additive upsert: a report's cost accrues across the initial generation
     // AND every chat turn. The upsert_roi_usage RPC sums cost/tokens/duration
     // and concatenates calls on conflict, so a cheap chat turn never overwrites
@@ -34,7 +40,7 @@ export async function persistUsage(
       p_report_id: ids.reportId,
       p_user_id: ids.userId ?? null,
       p_company: summary.company,
-      p_mode: summary.mode,
+      p_mode: persistedMode,
       p_duration_ms: summary.durationMs,
       p_input_tokens: summary.totals.inputTokens,
       p_output_tokens: summary.totals.outputTokens,
@@ -50,7 +56,7 @@ export async function persistUsage(
     await maybeSendUsageCostAlert({
       reportId: ids.reportId,
       company: summary.company,
-      mode: summary.mode,
+      mode: persistedMode,
       incrementCostUsd: summary.totals.costUsd,
     })
   } catch (err) {

--- a/src/lib/roi/services/usageTracker.ts
+++ b/src/lib/roi/services/usageTracker.ts
@@ -57,7 +57,7 @@ export interface UsageEntry {
 export interface UsageSummary {
   ts: string
   company: string
-  mode: 'generate' | 'chat'
+  mode: 'generate' | 'prepare' | 'finalize' | 'chat'
   durationMs: number
   calls: UsageEntry[]
   totals: {
@@ -73,13 +73,16 @@ export interface UsageSummary {
 export class UsageTracker {
   private company: string
 
-  private mode: 'generate' | 'chat'
+  private mode: 'generate' | 'prepare' | 'finalize' | 'chat'
 
   private startMs: number
 
   private entries: UsageEntry[] = []
 
-  constructor(opts: { company: string; mode: 'generate' | 'chat' }) {
+  constructor(opts: {
+    company: string
+    mode: 'generate' | 'prepare' | 'finalize' | 'chat'
+  }) {
     this.company = opts.company
     this.mode = opts.mode
     this.startMs = Date.now()


### PR DESCRIPTION
## Summary
- add a verification step in the ROI flow so users can review and edit company and workflow assumptions before final generation
- support follow-up generation paths for estimates-only and skip-LLM development flows
- persist verification updates and ROI usage tracking through the `/api/roi-agent` pipeline

## Testing
- `npm run lint`